### PR TITLE
fix version requirements of service.component import

### DIFF
--- a/bundles/ui/org.openhab.ui.dashboard/META-INF/MANIFEST.MF
+++ b/bundles/ui/org.openhab.ui.dashboard/META-INF/MANIFEST.MF
@@ -6,6 +6,6 @@ Bundle-Version: 2.0.0.qualifier
 Bundle-Vendor: openHAB.org
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Service-Component: OSGI-INF/dashboardservice.xml
-Import-Package: org.osgi.service.component;version="1.2.2",
+Import-Package: org.osgi.service.component;version="[1.2,2.0)",
  org.osgi.service.http;version="1.2.1",
  org.slf4j


### PR DESCRIPTION
The version of the service component package for OSGi Release 4 is using
the version 1.2.
The JavaDoc API states, that consumer of the API should use
version="[1.2,2.0)" for the version of the import.
I cannot find an implementation of the fixed version 1.2.2, perhaps this
is only supported by equinox.
Source: http://www.osgi.org/javadoc/r4v43/residential/org/osgi/service/component/package-summary.html
Signed-off-by: Markus Rathgeb <maggu2810@gmail.com>