### PR TITLE
sonos: fix missing import-package

### DIFF
--- a/addons/binding/org.openhab.binding.sonos/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.sonos/META-INF/MANIFEST.MF
@@ -22,7 +22,9 @@ Import-Package: com.google.common.collect,
  org.jupnp.model.meta,
  org.jupnp.model.types,
  org.osgi.service.component,
- org.slf4j
+ org.slf4j,
+ org.xml.sax,
+ org.xml.sax.helpers
 Service-Component: OSGI-INF/*
 Export-Package: org.openhab.binding.sonos,
  org.openhab.binding.sonos.handler


### PR DESCRIPTION
The file SonosXMLParser.java is using the following imports:
- org.xml.sax.Attributes;
- org.xml.sax.InputSource;
- org.xml.sax.SAXException;
- org.xml.sax.XMLReader;
- org.xml.sax.helpers.DefaultHandler;
- org.xml.sax.helpers.XMLReaderFactory;

The OSGi specification mandates that a bundle declare all package
depenencies using either Import-Package or Require-Bundle. The one
exception to this rule is the java.* packages which is always delegated
to the boot classpath. All other packages dependencies must be declared
in the bundle's manifest file.

Signed-off-by: Markus Rathgeb <maggu2810@gmail.com>