### PR TITLE
rename projects to prevent duplicates

### DIFF
--- a/distribution/.project
+++ b/distribution/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>distribution</name>
+	<name>oh2-distribution</name>
 	<comment></comment>
 	<projects>
 	</projects>

--- a/docs/sources/.project
+++ b/docs/sources/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>docs</name>
+	<name>oh2-docs</name>
 	<comment></comment>
 	<projects>
 	</projects>

--- a/targetplatform/.project
+++ b/targetplatform/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>targetplatform</name>
+	<name>oh2-targetplatform</name>
 	<comment></comment>
 	<projects>
 	</projects>

--- a/targetplatform/openHAB_Runtime.launch
+++ b/targetplatform/openHAB_Runtime.launch
@@ -19,7 +19,7 @@
 <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl} -consoleLog -console"/>
 <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.pde.ui.workbenchClasspathProvider"/>
 <stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Declipse.ignoreApp=true -Dosgi.clean=true -Dosgi.noShutdown=true -Dlogback.configurationFile=./runtime/etc/logback_debug.xml -Djava.library.path=./lib -Djetty.home.bundle=org.openhab.io.jetty -Dorg.quartz.properties=./runtime/etc/quartz.properties -Dorg.osgi.service.http.port=8080 -Dorg.osgi.service.http.port.secure=8443 -DmdnsName=openhab -Dopenhab.logdir=./userdata/logs -Dsmarthome.servicecfg=./runtime/etc/services.cfg -Dsmarthome.servicepid=org.openhab -Dsmarthome.userdata=userdata -Djetty.etc.config.urls=etc/jetty.xml,etc/jetty-ssl.xml,etc/jetty-deployer.xml,etc/jetty-https.xml,etc/jetty-selector.xml"/>
-<stringAttribute key="org.eclipse.jdt.launching.WORKING_DIRECTORY" value="${workspace_loc:distribution/openhabhome}"/>
+<stringAttribute key="org.eclipse.jdt.launching.WORKING_DIRECTORY" value="${workspace_loc:oh2-distribution/openhabhome}"/>
 <stringAttribute key="pde.version" value="3.3"/>
 <stringAttribute key="product" value=""/>
 <stringAttribute key="productFile" value="/org.openhab.runtime.product/org.openhab.runtime.product.product"/>


### PR DESCRIPTION
Reduce probability for project name duplicates for "common" project names.
If you fill your IDE with multiple stuff, a more specific project name would be nice.
The project name of the bundles suffer this requirement already as it is using the BSN.
Add an "oh2-" prefix to the Eclipse projects "distribution", "docs" and "targetplatform".