### PR TITLE
stop add workspace plugins automatically to launch config

### DIFF
--- a/targetplatform/openHAB_Runtime.launch
+++ b/targetplatform/openHAB_Runtime.launch
@@ -2,7 +2,7 @@
 <launchConfiguration type="org.eclipse.pde.ui.RuntimeWorkbench">
 <booleanAttribute key="append.args" value="true"/>
 <booleanAttribute key="askclear" value="false"/>
-<booleanAttribute key="automaticAdd" value="true"/>
+<booleanAttribute key="automaticAdd" value="false"/>
 <booleanAttribute key="automaticValidate" value="true"/>
 <stringAttribute key="bootstrap" value=""/>
 <stringAttribute key="checked" value="[NONE]"/>
@@ -12,7 +12,6 @@
 <stringAttribute key="configLocation" value="${workspace_loc}/.metadata/.plugins/org.eclipse.pde.core/openHAB_Runtime"/>
 <booleanAttribute key="default" value="false"/>
 <booleanAttribute key="default_auto_start" value="true"/>
-<stringAttribute key="deselected_workspace_plugins" value="org.openhab.binding.max.test"/>
 <booleanAttribute key="includeOptional" value="true"/>
 <stringAttribute key="location" value="${workspace_loc}/../runtime-org.openhab.runtime.product.product"/>
 <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>


### PR DESCRIPTION
It is very annoying if every bundle I added to my workspace is also
added to the launch configuration and must be deactivated manually.
A launch configuration should represent a configuration that is changed
manually if additional bundles should be added.

If the automatically addition of plugins is deactivated, we could stop
adding plugins to deselected_workspace_plugins.

Signed-off-by: Markus Rathgeb <maggu2810@gmail.com>