### PR TITLE
classpath's JRE container and execution enviroment's one does not fit

### DIFF
--- a/bundles/core/org.openhab.core.init/.classpath
+++ b/bundles/core/org.openhab.core.init/.classpath
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" output="target/classes" path="src/main/java"/>
 	<classpathentry excluding="**" kind="src" output="target/classes" path="src/main/resources"/>
-	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/bundles/core/org.openhab.core.init/.settings/org.eclipse.jdt.core.prefs
+++ b/bundles/core/org.openhab.core.init/.settings/org.eclipse.jdt.core.prefs
@@ -1,2 +1,8 @@
 eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.7
+org.eclipse.jdt.core.compiler.compliance=1.7
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
+org.eclipse.jdt.core.compiler.source=1.7

--- a/bundles/core/org.openhab.core/.classpath
+++ b/bundles/core/org.openhab.core/.classpath
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" output="target/classes" path="src/main/java"/>
 	<classpathentry excluding="**" kind="src" output="target/classes" path="src/main/resources"/>
-	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/bundles/core/org.openhab.core/.settings/org.eclipse.jdt.core.prefs
+++ b/bundles/core/org.openhab.core/.settings/org.eclipse.jdt.core.prefs
@@ -1,2 +1,8 @@
 eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.7
+org.eclipse.jdt.core.compiler.compliance=1.7
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
+org.eclipse.jdt.core.compiler.source=1.7

--- a/bundles/io/org.openhab.io.transport.serial/.classpath
+++ b/bundles/io/org.openhab.io.transport.serial/.classpath
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry exported="true" kind="lib" path="lib/nrjavaserial-3.8.8.jar"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/bundles/io/org.openhab.io.transport.serial/META-INF/MANIFEST.MF
+++ b/bundles/io/org.openhab.io.transport.serial/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: openHAB Serial Transport Bundle
 Bundle-SymbolicName: org.openhab.io.transport.serial
 Bundle-Version: 2.0.0.qualifier
 Bundle-Vendor: openHAB.org
-Bundle-RequiredExecutionEnvironment: J2SE-1.5
+Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ClassPath: lib/nrjavaserial-3.8.8.jar
 Export-Package: gnu.io
 Import-Package: gnu.io


### PR DESCRIPTION
Fix "The JRE container on the classpath is not a perfect match to the
'J2SE-1.5' execution environment" for org.openhab.io.transport.serial.

Fix "The JRE container on the classpath is not a perfect match to the
'JavaSE-1.7' execution environment" for org.openhab.core.init and
org.openhab.core.