### PR TITLE
Fix a bug in the implementation of DiscoveryListener of the ZonePlayerHa...

### DIFF
--- a/addons/binding/org.openhab.binding.sonos/src/main/java/org/openhab/binding/sonos/handler/ZonePlayerHandler.java
+++ b/addons/binding/org.openhab.binding.sonos/src/main/java/org/openhab/binding/sonos/handler/ZonePlayerHandler.java
@@ -165,21 +165,25 @@ UpnpIOParticipant, DiscoveryListener {
 
 	@Override
 	public void thingDiscovered(DiscoveryService source, DiscoveryResult result) {
-		if (getThing().getConfiguration().get(UDN)
-				.equals(result.getProperties().get(UDN))) {
-			logger.debug("Discovered UDN '{}' for thing '{}'", result
-					.getProperties().get(UDN), getThing().getUID());
-			getThing().setStatus(ThingStatus.ONLINE);
-			onSubscription();
-			onUpdate();
+		if(result.getThingUID().equals(this.getThing().getUID())) {
+			if (getThing().getConfiguration().get(UDN)
+					.equals(result.getProperties().get(UDN))) {
+				logger.debug("Discovered UDN '{}' for thing '{}'", result
+						.getProperties().get(UDN), getThing().getUID());
+				getThing().setStatus(ThingStatus.ONLINE);
+				onSubscription();
+				onUpdate();
+			}
 		}
 	}
 
 	@Override
 	public void thingRemoved(DiscoveryService source, ThingUID thingUID) {
-		logger.debug("Setting status for thing '{}' to OFFLINE", getThing()
-				.getUID());
-		getThing().setStatus(ThingStatus.OFFLINE);
+		if(thingUID.equals(this.getThing().getUID())) {
+			logger.debug("Setting status for thing '{}' to OFFLINE", getThing()
+					.getUID());
+			getThing().setStatus(ThingStatus.OFFLINE);
+		}
 	}
 
 	@Override
@@ -1210,7 +1214,7 @@ UpnpIOParticipant, DiscoveryListener {
 	public void setPositionTrack(long tracknr) {
 		seek("TRACK_NR", Long.toString(tracknr));
 	}
-	
+
 	public void setPositionTrack(String tracknr) {
 		seek("TRACK_NR", tracknr);		
 	}


### PR DESCRIPTION
...ndler

Note for other binding developers: DiscoveryListeners get called on the discovery of any Thing, e.g. there is no selectivity, and it is up to the DiscoveryListener implementor to check if the ThingUID is valid or not

Signed-off-by: Karel Goderis <karel.goderis@me.com>