### PR TITLE
Format start scripts and add check for not found equinox launcher

### DIFF
--- a/distribution/openhabhome/start.bat
+++ b/distribution/openhabhome/start.bat
@@ -1,7 +1,7 @@
 @echo off
 
 :: set path to eclipse folder. If local folder, use '.'; otherwise, use c:\path\to\eclipse
-set ECLIPSEHOME="runtime\server"
+set ECLIPSEHOME=server
 
 :: set ports for HTTP(S) server
 set HTTP_PORT=8080
@@ -9,10 +9,29 @@ set HTTPS_PORT=8443
  
 :: get path to equinox jar inside ECLIPSEHOME folder
 for /f "delims= tokens=1" %%c in ('dir /B /S /OD %ECLIPSEHOME%\plugins\org.eclipse.equinox.launcher_*.jar') do set EQUINOXJAR=%%c
- 
-:: program params
-set PROG_ARGS=-Dlogback.configurationFile=./runtime/etc/logback.xml -DmdnsName=openhab -Dopenhab.logdir=./userdata/logs -Dsmarthome.servicecfg=./runtime/etc/services.cfg -Dsmarthome.userdata=./userdata -Dsmarthome.servicepid=org.openhab -Dorg.quartz.properties=./runtime/etc/quartz.properties -Djetty.etc.config.urls=etc/jetty.xml,etc/jetty-ssl.xml,etc/jetty-deployer.xml,etc/jetty-https.xml,etc/jetty-selector.xml
 
+IF NOT [%EQUINOXJAR%] == [] GOTO :Launch
+echo No equinox launcher in path '%ECLIPSEHOME%' found!
+goto :eof
+
+:Launch 
 :: start Eclipse w/ java
 echo Launching the openHAB runtime...
-java %PROG_ARGS% -Dosgi.clean=true -Declipse.ignoreApp=true -Dosgi.noShutdown=true -Djetty.home.bundle=org.openhab.io.jetty -Dorg.osgi.service.http.port=%HTTP_PORT% -Dorg.osgi.service.http.port.secure=%HTTPS_PORT% -Dfelix.fileinstall.dir=addons -Djava.library.path=lib -Dequinox.ds.block_timeout=240000 -Dequinox.scr.waitTimeOnBlock=60000 -Dfelix.fileinstall.active.level=4 -Djava.awt.headless=true -jar %EQUINOXJAR% %* -console 
+java ^
+-Dosgi.clean=true ^
+-Declipse.ignoreApp=true ^
+-Dosgi.noShutdown=true ^
+-Djetty.port=%HTTP_PORT% ^
+-Djetty.port.ssl=%HTTPS_PORT% ^
+-Djetty.home=. ^
+-Dlogback.configurationFile=configurations/logback.xml ^
+-Dfelix.fileinstall.dir=addons ^
+-Djava.library.path=lib ^
+-Djava.security.auth.login.config=./etc/login.conf ^
+-Dorg.quartz.properties=./etc/quartz.properties ^
+-Dequinox.ds.block_timeout=240000 ^
+-Dequinox.scr.waitTimeOnBlock=60000 ^
+-Djava.awt.headless=true ^
+-Dfelix.fileinstall.active.level=4 ^
+-jar %EQUINOXJAR% %* ^
+-console 

--- a/distribution/openhabhome/start.sh
+++ b/distribution/openhabhome/start.sh
@@ -12,8 +12,27 @@ HTTPS_PORT=8443
 # get path to equinox jar inside $eclipsehome folder
 cp=$(find $eclipsehome -name "org.eclipse.equinox.launcher_*.jar" | sort | tail -1);
 
+if [ -z "$cp" ]; then
+	echo "Error: Could not find equinox launcher in path $eclipsehome" 1>&2
+	exit 1
+fi
+
 # program args
 prog_args="-Dlogback.configurationFile=./runtime/etc/logback.xml -DmdnsName=openhab -Dopenhab.logdir=./userdata/logs -Dsmarthome.servicecfg=./runtime/etc/services.cfg -Dsmarthome.servicepid=org.openhab -Dsmarthome.userdata=./userdata -Dorg.quartz.properties=./runtime/etc/quartz.properties -Djetty.etc.config.urls=etc/jetty.xml,etc/jetty-ssl.xml,etc/jetty-deployer.xml,etc/jetty-https.xml,etc/jetty-selector.xml"
 
 echo Launching the openHAB runtime...
-java $prog_args -Dosgi.clean=true -Declipse.ignoreApp=true -Dosgi.noShutdown=true -Djetty.home.bundle=org.openhab.io.jetty -Dorg.osgi.service.http.port=$HTTP_PORT -Dorg.osgi.service.http.port.secure=$HTTPS_PORT -Dfelix.fileinstall.dir=addons -Djava.library.path=lib -Dequinox.ds.block_timeout=240000 -Dequinox.scr.waitTimeOnBlock=60000 -Dfelix.fileinstall.active.level=4 -Djava.awt.headless=true -jar $cp $* -console 
+java $prog_args \
+	-Dosgi.clean=true \
+	-Declipse.ignoreApp=true \
+	-Dosgi.noShutdown=true \
+	-Djetty.home.bundle=org.openhab.io.jetty \
+	-Dorg.osgi.service.http.port=$HTTP_PORT \
+	-Dorg.osgi.service.http.port.secure=$HTTPS_PORT \
+	-Dfelix.fileinstall.dir=addons \
+	-Djava.library.path=lib \
+	-Dequinox.ds.block_timeout=240000 \
+	-Dequinox.scr.waitTimeOnBlock=60000 \
+	-Dfelix.fileinstall.active.level=4 \
+	-Djava.awt.headless=true \
+	-jar $cp $* \
+	-console

--- a/distribution/openhabhome/start_debug.sh
+++ b/distribution/openhabhome/start_debug.sh
@@ -12,6 +12,11 @@ HTTPS_PORT=8443
 # get path to equinox jar inside $eclipsehome folder
 cp=$(find $eclipsehome -name "org.eclipse.equinox.launcher_*.jar" | sort | tail -1);
 
+if [ -z "$cp" ]; then
+	echo "Error: Could not find equinox launcher in path $eclipsehome" 1>&2
+	exit 1
+fi
+
 # debug options
 debug_opts="-Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,address=8001,server=y,suspend=n"
 
@@ -19,4 +24,18 @@ debug_opts="-Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket
 prog_args="-Dlogback.configurationFile=./runtime/etc/logback_debug.xml -DmdnsName=openhab -Dopenhab.logdir=./userdata/logs -Dsmarthome.servicecfg=./runtime/etc/services.cfg -Dsmarthome.servicepid=org.openhab -Dsmarthome.userdata=./userdata -Dorg.quartz.properties=./runtime/etc/quartz.properties -Djetty.etc.config.urls=etc/jetty.xml,etc/jetty-ssl.xml,etc/jetty-deployer.xml,etc/jetty-https.xml,etc/jetty-selector.xml"
 
 echo Launching the openHAB runtime in debug mode...
-java $debug_opts $prog_args -Dosgi.clean=true -Declipse.ignoreApp=true -Dosgi.noShutdown=true -Djetty.home.bundle=org.openhab.io.jetty -Dorg.osgi.service.http.port=$HTTP_PORT -Dorg.osgi.service.http.port.secure=$HTTPS_PORT -Dfelix.fileinstall.dir=addons -Djava.library.path=lib -Dequinox.ds.block_timeout=240000 -Dequinox.scr.waitTimeOnBlock=60000 -Dfelix.fileinstall.active.level=4 -Djava.awt.headless=true -jar $cp $* -console 
+java $debug_opts $prog_args \
+	-Dosgi.clean=true \
+	-Declipse.ignoreApp=true \
+	-Dosgi.noShutdown=true \
+	-Djetty.home.bundle=org.openhab.io.jetty \
+	-Dorg.osgi.service.http.port=$HTTP_PORT \
+	-Dorg.osgi.service.http.port.secure=$HTTPS_PORT \
+	-Dfelix.fileinstall.dir=addons \
+	-Djava.library.path=lib \
+	-Dequinox.ds.block_timeout=240000 \
+	-Dequinox.scr.waitTimeOnBlock=60000 \
+	-Dfelix.fileinstall.active.level=4 \
+	-Djava.awt.headless=true \
+	-jar $cp $* \
+	-console 


### PR DESCRIPTION
If the equinox launcher jar is not present, there was no error message.

This was done in openHAB1, too.

Signed-off-by: Sebastian Janzen <sebastian@janzen.it>