### PR TITLE
Update serial library from 3.8.8 to 3.9.3 for compatibility with OH1

### DIFF
--- a/bundles/io/org.openhab.io.transport.serial/META-INF/MANIFEST.MF
+++ b/bundles/io/org.openhab.io.transport.serial/META-INF/MANIFEST.MF
@@ -5,6 +5,6 @@ Bundle-SymbolicName: org.openhab.io.transport.serial
 Bundle-Version: 2.0.0.qualifier
 Bundle-Vendor: openHAB.org
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
-Bundle-ClassPath: lib/nrjavaserial-3.8.8.jar
+Bundle-ClassPath: lib/nrjavaserial-3.9.3.jar
 Export-Package: gnu.io
 Import-Package: gnu.io


### PR DESCRIPTION
Sorry - I missed the manifest!
Signed-off-by: Chris Jackson <chris@cd-jackson.com> (github: cdjackson)