### PR TITLE
Ignore new launch files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ bundles/io/org.openhab.io.multimedia.tts.marytts/lib/
 .antlr*
 .metadata/
 */plugin.xml_gen
+targetplatform/*.launch
 
 distribution/openhabhome/logs/*.log
 distribution/openhabhome/*.zip


### PR DESCRIPTION
While developing, I duplicate the default launch file and modify it to my needs. Those launchers, I do not want to commit, should be ignored by git. If the maintainers change the default launchers, they appear as a normal change, because they're already committed. So there should be no reason not to ignore targetplatform/*.launch

Signed-off-by: Sebastian Janzen <sebastian@janzen.it>