### PR TITLE
Improve behavior when network is interrupted (e.g. laptop sleeps)

### DIFF
--- a/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/discovery/MaxCubeBridgeDiscovery.java
+++ b/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/discovery/MaxCubeBridgeDiscovery.java
@@ -90,7 +90,7 @@ public class MaxCubeBridgeDiscovery extends AbstractDiscoveryService {
 	protected void startBackgroundDiscovery() {
 		logger.debug("Start MAX! Cube background discovery");
 		if (cubeDiscoveryJob == null || cubeDiscoveryJob.isCancelled()) {
-			cubeDiscoveryJob = scheduler.scheduleAtFixedRate(cubeDiscoveryRunnable, 0, refreshInterval, TimeUnit.SECONDS);
+			cubeDiscoveryJob = scheduler.scheduleAtFixedRate(cubeDiscoveryRunnable, 10, refreshInterval, TimeUnit.SECONDS);
 		}
 	}
 

--- a/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/discovery/MaxCubeBridgeDiscovery.java
+++ b/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/discovery/MaxCubeBridgeDiscovery.java
@@ -103,10 +103,7 @@ public class MaxCubeBridgeDiscovery extends AbstractDiscoveryService {
 	}
 
 	private void receiveDiscoveryMessage() {
-		String maxCubeIP = null;
-		String maxCubeName = null;
-		String serialNumber = null;
-		String rfAddress = null;
+
 		DatagramSocket bcReceipt = null;
 
 		try {
@@ -122,23 +119,32 @@ public class MaxCubeBridgeDiscovery extends AbstractDiscoveryService {
 				bcReceipt.receive(receivePacket);
 
 				// We have a response
-				String message = new String(receivePacket.getData()).trim();
+				String message = new String(receivePacket.getData(), receivePacket.getOffset(),
+						receivePacket.getLength());
 				logger.trace("Broadcast response from {} : {} '{}'", receivePacket.getAddress(), message.length(),
 						message);
 
 				// Check if the message is correct
 				if (message.startsWith("eQ3Max") && !message.equals(MAXCUBE_DISCOVER_STRING)) {
-					maxCubeIP = receivePacket.getAddress().getHostAddress();
-					maxCubeName = message.substring(0, 8);
-					serialNumber = message.substring(8, 18);
-					byte[] unknownData = message.substring(18, 21).getBytes();
-					rfAddress = Utils.getHex(message.substring(21).getBytes()).replace(" ", "").toLowerCase();
+					String maxCubeIP = receivePacket.getAddress().getHostAddress();
+					String maxCubeState = message.substring(0, 8);
+					String serialNumber = message.substring(8, 18);
+					String msgValidid = message.substring(18, 19);
+					String requestType = message.substring(19, 20);
 					logger.debug("MAX! Cube found on network");
 					logger.debug("Found at  : {}", maxCubeIP);
-					logger.debug("Name      : {}", maxCubeName);
+					logger.debug("Cube State: {}", maxCubeState);
 					logger.debug("Serial    : {}", serialNumber);
-					logger.debug("RF Address: {}", rfAddress);
-					logger.trace("Unknown   : {}", Utils.getHex(unknownData));
+					logger.trace("Msg Valid : {}", msgValidid);
+					logger.trace("Msg Type  : {}", requestType);
+
+					if (requestType.equals( "I")) {
+						String rfAddress = Utils.getHex(message.substring(21, 24).getBytes()).replace(" ", "")
+								.toLowerCase();
+						String firmwareVersion = Utils.getHex(message.substring(24, 26).getBytes()).replace(" ", ".");
+						logger.debug("RF Address: {}", rfAddress);
+						logger.debug("Firmware  : {}", firmwareVersion);
+					}
 					discoveryResultSubmission(maxCubeIP, serialNumber);
 				}
 			}

--- a/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/handler/MaxCubeBridgeHandler.java
+++ b/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/handler/MaxCubeBridgeHandler.java
@@ -22,7 +22,6 @@ import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ScheduledFuture;

--- a/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/handler/MaxCubeBridgeHandler.java
+++ b/addons/binding/org.openhab.binding.max/src/main/java/org/openhab/binding/max/internal/handler/MaxCubeBridgeHandler.java
@@ -197,10 +197,10 @@ public class MaxCubeBridgeHandler extends BaseBridgeHandler {
 
 	private synchronized void startAutomaticRefresh() {
 		if (pollingJob == null || pollingJob.isCancelled()) {
-			pollingJob = scheduler.scheduleAtFixedRate(pollingRunnable, 0, refreshInterval, TimeUnit.MILLISECONDS);
+			pollingJob = scheduler.scheduleWithFixedDelay(pollingRunnable, 0, refreshInterval, TimeUnit.MILLISECONDS);
 		}
 		if (sendCommandJob == null || sendCommandJob.isCancelled()) {
-			sendCommandJob = scheduler.scheduleAtFixedRate(sendCommandRunnable, 0, sendCommandInterval,
+			sendCommandJob = scheduler.scheduleWithFixedDelay(sendCommandRunnable, 0, sendCommandInterval,
 					TimeUnit.MILLISECONDS);
 		}
 	}
@@ -214,10 +214,18 @@ public class MaxCubeBridgeHandler extends BaseBridgeHandler {
 
 		SendCommand sendCommand = commandQueue.poll();
 		if (sendCommand != null) {
-			executeCommand(sendCommand);
+			String commandString = getCommandString(sendCommand);
+			// Actual sending of the data to the Max!Cube Lan Gateway
+			if (sendCubeCommand(commandString)) {
+				logger.debug("Command {} ({}) sent to MAX! Cube at IP: {}", sendCommand.getId(), sendCommand.getKey(),
+						ipAddress);
+			} else
+				logger.warn("Error sending command {} ({}) to MAX! Cube at IP: {}", sendCommand.getId(),
+						sendCommand.getKey(), ipAddress);
+
 		}
 	}
-
+	
 	/**
 	 * initiates read data from the maxCube bridge
 	 */
@@ -561,7 +569,7 @@ public class MaxCubeBridgeHandler extends BaseBridgeHandler {
 	 *            String the channelUID used to send the command and the the
 	 *            command data
 	 */
-	public void executeCommand(SendCommand sendCommand) {
+	private String getCommandString(SendCommand sendCommand) {
 
 		String serialNumber = sendCommand.getDeviceSerial();
 		ChannelUID channelUID = sendCommand.getChannelUID();
@@ -572,7 +580,7 @@ public class MaxCubeBridgeHandler extends BaseBridgeHandler {
 
 		if (device == null) {
 			logger.debug("Cannot send command to device with serial number {}, device not listed.", serialNumber);
-			return;
+			return null;
 		}
 
 		String rfAddress = device.getRFAddress();
@@ -613,12 +621,21 @@ public class MaxCubeBridgeHandler extends BaseBridgeHandler {
 				} else {
 					logger.debug("Only updates to AUTOMATIC & BOOST & MANUAL supported, received value :'{}'",
 							commandContent);
-					return;
+					return null;
 				}
 				commandString = cmd.getCommandString();
 			}
 		}
-		// Actual sending of the data to the Max!Cube Lan Gateway
+		return commandString;
+	}
+
+	/**
+	 * Send a command string to Cube
+	 * 
+	 * @param commandString
+	 */
+	private boolean sendCubeCommand(String commandString) {
+		boolean sendSuccess = false;
 		synchronized (MaxCubeBridgeHandler.class) {
 			if (commandString != null) {
 				try {
@@ -627,14 +644,17 @@ public class MaxCubeBridgeHandler extends BaseBridgeHandler {
 					}
 					writer.write(commandString);
 					writer.flush();
+
 					String raw = reader.readLine();
-					Message message = processRawMessage(raw);
-					if (message != null)
-						processMessage(message);
+					if (raw != null) {
+						Message message = processRawMessage(raw);
+						if (message != null)
+							processMessage(message);
+					}
 					if (!exclusive) {
 						socketClose();
 					}
-
+					sendSuccess = true;
 				} catch (UnknownHostException e) {
 					logger.warn("Cannot establish connection with MAX! Cube lan gateway while sending command to '{}'",
 							ipAddress);
@@ -645,17 +665,17 @@ public class MaxCubeBridgeHandler extends BaseBridgeHandler {
 					logger.debug(Utils.getStackTrace(e));
 					socketClose(); // reconnect on next execution
 				}
-				logger.debug("Command {} ({}) sent to MAX! Cube at IP: {}", sendCommand.getId(), sendCommand.getKey(),
-						ipAddress);
-				logger.trace("Command {} content: '{}'", sendCommand.getId(), commandString);
+				logger.trace("Command content: '{}'", commandString);
 			} else {
 				logger.debug("Null Command not sent to {}", ipAddress);
 			}
 		}
+		return sendSuccess;
 	}
 
 	private boolean socketConnect() throws UnknownHostException, IOException {
 		socket = new Socket(ipAddress, port);
+		socket.setSoTimeout((int) (2000));
 		logger.debug("Open new connection... to {} port {}", ipAddress, port);
 		reader = new BufferedReader(new InputStreamReader(socket.getInputStream()));
 		writer = new OutputStreamWriter(socket.getOutputStream());


### PR DESCRIPTION
* Improve behavior when network is interrupted (e.g. laptop sleeps) by
using a fixed delay instead of fixed rate
* Improve the discovery results reading
* refactor the messages sending to allow better unit testing (separate
the content determination from the sending)
* Removed one findbugs warning/ nullpointerexception when no reply from cube is coming