### PR TITLE
Pass on ItemNotFoundException in compat ItemRegistry

### DIFF
--- a/bundles/core/org.openhab.core.compat1x/src/main/java/org/openhab/core/items/internal/ItemUIRegistryDelegate.java
+++ b/bundles/core/org.openhab.core.compat1x/src/main/java/org/openhab/core/items/internal/ItemUIRegistryDelegate.java
@@ -41,7 +41,12 @@ public class ItemUIRegistryDelegate implements ItemUIRegistry, RegistryChangeLis
 
     @Override
     public Item getItem(String name) throws ItemNotFoundException {
-        org.eclipse.smarthome.core.items.Item eshItem = itemUIRegistry.get(name);
+        org.eclipse.smarthome.core.items.Item eshItem;
+        try {
+            eshItem = itemUIRegistry.getItem(name);
+        } catch (org.eclipse.smarthome.core.items.ItemNotFoundException e) {
+            throw new ItemNotFoundException(name);
+        }
         return ItemMapper.mapToOpenHABItem(eshItem);
     }
 


### PR DESCRIPTION
This is a solution for #267. If there's a good reason for the current implementation then just ignore this :-)  