### PR TITLE
Update addons.md

### DIFF
--- a/docs/sources/addons.md
+++ b/docs/sources/addons.md
@@ -65,3 +65,9 @@ All optional add-ons for openHAB 2 are [available in a separate download](https:
 | XBMC | Action |
 | XMPP | Action |
 | MaryTTS | TTS engine |
+
+## Compatible Applications
+
+| Application | Description |
+|-------|----------------------|
+| [iot_bridge](https://github.com/openhab/openhab/wiki/ROS-Robot-Operating-System) | Bridge between ROS Robot Operating System and OpenHAB |


### PR DESCRIPTION
Added a section for applications that have been tested with OH2.  Iot_bridge uses the OH Rest interface and worked without modification.