### PR TITLE
Fix Jetty RewriteHandler rules order for proxies

### DIFF
--- a/bundles/io/org.openhab.io.jetty/jettyhome/etc/jetty.xml
+++ b/bundles/io/org.openhab.io.jetty/jettyhome/etc/jetty.xml
@@ -29,17 +29,6 @@
 				<Array type="org.eclipse.jetty.server.Handler">
 					<Item>
 						<New id="Rewrite" class="org.eclipse.jetty.rewrite.handler.RewriteHandler">
-						
-							<!-- show the dashboard as default -->
-							<Call name="addRule">
-							  <Arg>
-							    <New class="org.eclipse.jetty.rewrite.handler.RedirectRegexRule">
-							      <Set name="regex">/$</Set>
-							      <Set name="replacement">/start/index</Set>
-							    </New>
-							  </Arg>
-							</Call>
-
 							<!-- Add rule in order to take care of the X-Forwarded-Scheme header -->
 							<Call name="addRule">
 								<Arg>
@@ -60,6 +49,16 @@
 										<Set name="scheme">http</Set>
 									</New>
 								</Arg>
+							</Call>
+							
+							<!-- show the dashboard as default -->
+							<Call name="addRule">
+							  <Arg>
+							    <New class="org.eclipse.jetty.rewrite.handler.RedirectRegexRule">
+							      <Set name="regex">/$</Set>
+							      <Set name="replacement">/start/index</Set>
+							    </New>
+							  </Arg>
 							</Call>
 						</New>
 					</Item>

--- a/docs/sources/configuration/jetty.md
+++ b/docs/sources/configuration/jetty.md
@@ -18,7 +18,7 @@ The configuration assumes that you run the reverse proxy on the same machine as 
 	
 		location / {
 			proxy_pass                            http://localhost:8080/;
-			proxy_set_header Host                 $host;
+			proxy_set_header Host                 $http_host;
 			proxy_set_header X-Real-IP            $remote_addr;
 			proxy_set_header X-Forwarded-For      $proxy_add_x_forwarded_for;
 			proxy_set_header X-Forwarded-Scheme   $scheme;		
@@ -45,7 +45,7 @@ Maybe you do not trust the local network. In this case it's possible to pass the
 	
 		location / {
 			proxy_pass                            http://localhost:8080/;
-			proxy_set_header Host                 $host;
+			proxy_set_header Host                 $http_host;
 			proxy_set_header X-Real-IP            $remote_addr;
 			proxy_set_header X-Forwarded-For      $proxy_add_x_forwarded_for;
 			proxy_set_header X-Forwarded-Scheme   $scheme;		


### PR DESCRIPTION
Moves the dashboard redirect to the bottom of the RewriteHandler rules in the Jetty configuration so that the X-Forwarded-Scheme rules can be applied first.

Fixes #317
Signed-off-by: Andy Lintner <dev@beowulfe.com> (github: beowulfe)