### PR TITLE
Karaf: use env for finalname path (needs K402)

### DIFF
--- a/features/org.openhab.feature.addons/src/main/feature/feature.xml
+++ b/features/org.openhab.feature.addons/src/main/feature/feature.xml
@@ -8,13 +8,13 @@
     <feature name="openhab2-addon-action-mail" description="" version="${project.version}">
         <feature>openhab2-runtime-compat1x</feature>
         <bundle start-level="80">mvn:org.openhab.action/org.openhab.action.mail/${oh1.version}</bundle>
-        <configfile finalname="conf/services/mail.cfg" override="false">mvn:${project.groupId}/org.openhab.feature.addons.external/${project.version}/cfg/mail</configfile>
+        <configfile finalname="${openhab.conf}/services/mail.cfg" override="false">mvn:${project.groupId}/org.openhab.feature.addons.external/${project.version}/cfg/mail</configfile>
     </feature>
 
     <feature name="openhab2-addon-action-pushover" description="" version="${project.version}">
         <feature>openhab2-runtime-compat1x</feature>
         <bundle start-level="80">mvn:org.openhab.action/org.openhab.action.pushover/${oh1.version}</bundle>
-        <configfile finalname="conf/services/pushover.cfg" override="false">mvn:${project.groupId}/org.openhab.feature.addons.external/${project.version}/cfg/pushover</configfile>
+        <configfile finalname="${openhab.conf}/services/pushover.cfg" override="false">mvn:${project.groupId}/org.openhab.feature.addons.external/${project.version}/cfg/pushover</configfile>
     </feature>
 
     <feature name="openhab2-addon-action-xbmc" description="" version="${project.version}">
@@ -25,7 +25,7 @@
     <feature name="openhab2-addon-action-xmpp" description="" version="${project.version}">
         <feature>openhab2-runtime-compat1x</feature>
         <bundle start-level="80">mvn:org.openhab.action/org.openhab.action.xmpp/${oh1.version}</bundle>
-        <configfile finalname="conf/services/xmpp.cfg" override="false">mvn:${project.groupId}/org.openhab.feature.addons.external/${project.version}/cfg/xmpp</configfile>
+        <configfile finalname="${openhab.conf}/services/xmpp.cfg" override="false">mvn:${project.groupId}/org.openhab.feature.addons.external/${project.version}/cfg/xmpp</configfile>
     </feature>
 
     <!-- binding -->
@@ -33,13 +33,13 @@
     <feature name="openhab2-addon-binding-anel" description="" version="${project.version}">
         <feature>openhab2-runtime-compat1x</feature>
         <bundle start-level="80">mvn:org.openhab.binding/org.openhab.binding.anel/${oh1.version}</bundle>
-        <configfile finalname="conf/services/anel.cfg" override="false">mvn:${project.groupId}/org.openhab.feature.addons.external/${project.version}/cfg/anel</configfile>
+        <configfile finalname="${openhab.conf}/services/anel.cfg" override="false">mvn:${project.groupId}/org.openhab.feature.addons.external/${project.version}/cfg/anel</configfile>
     </feature>
 
     <feature name="openhab2-addon-binding-astro1" description="" version="${project.version}">
         <feature>openhab2-runtime-compat1x</feature>
         <bundle start-level="80">mvn:org.openhab.binding/org.openhab.binding.astro/${oh1.version}</bundle>
-        <configfile finalname="conf/services/astro.cfg" override="false">mvn:${project.groupId}/org.openhab.feature.addons.external/${project.version}/cfg/astro</configfile>
+        <configfile finalname="${openhab.conf}/services/astro.cfg" override="false">mvn:${project.groupId}/org.openhab.feature.addons.external/${project.version}/cfg/astro</configfile>
     </feature>
 
     <feature name="openhab2-addon-binding-astro" description="" version="${project.version}">
@@ -57,7 +57,7 @@
     <feature name="openhab2-addon-binding-denon" description="" version="${project.version}">
         <feature>openhab2-runtime-compat1x</feature>
         <bundle start-level="80">mvn:org.openhab.binding/org.openhab.binding.denon/${oh1.version}</bundle>
-        <configfile finalname="conf/services/denon.cfg" override="false">mvn:${project.groupId}/org.openhab.feature.addons.external/${project.version}/cfg/denon</configfile>
+        <configfile finalname="${openhab.conf}/services/denon.cfg" override="false">mvn:${project.groupId}/org.openhab.feature.addons.external/${project.version}/cfg/denon</configfile>
     </feature>
 
     <feature name="openhab2-addon-binding-energenie" description="" version="${project.version}">
@@ -69,14 +69,14 @@
         <feature>openhab2-runtime-compat1x</feature>
         <feature>openhab2-addon-transport-serial</feature>
         <bundle start-level="80">mvn:org.openhab.binding/org.openhab.binding.enocean/${oh1.version}</bundle>
-        <configfile finalname="conf/services/enocean.cfg" override="false">mvn:${project.groupId}/org.openhab.feature.addons.external/${project.version}/cfg/enocean</configfile>
+        <configfile finalname="${openhab.conf}/services/enocean.cfg" override="false">mvn:${project.groupId}/org.openhab.feature.addons.external/${project.version}/cfg/enocean</configfile>
     </feature>
 
     <feature name="openhab2-addon-binding-epsonprojector" description="" version="${project.version}">
         <feature>openhab2-runtime-compat1x</feature>
         <feature>openhab2-addon-transport-serial</feature>
         <bundle start-level="80">mvn:org.openhab.binding/org.openhab.binding.epsonprojector/${oh1.version}</bundle>
-        <configfile finalname="conf/services/epsonprojector.cfg" override="false">mvn:${project.groupId}/org.openhab.feature.addons.external/${project.version}/cfg/epsonprojector</configfile>
+        <configfile finalname="${openhab.conf}/services/epsonprojector.cfg" override="false">mvn:${project.groupId}/org.openhab.feature.addons.external/${project.version}/cfg/epsonprojector</configfile>
     </feature>
 
     <feature name="openhab2-addon-binding-exec" description="" version="${project.version}">
@@ -91,7 +91,7 @@
     <feature name="openhab2-addon-binding-freeswitch" description="" version="${project.version}">
         <feature>openhab2-runtime-compat1x</feature>
         <bundle start-level="80">mvn:org.openhab.binding/org.openhab.binding.freeswitch/${oh1.version}</bundle>
-        <configfile finalname="conf/services/freeswitch.cfg" override="false">mvn:${project.groupId}/org.openhab.feature.addons.external/${project.version}/cfg/freeswitch</configfile>
+        <configfile finalname="${openhab.conf}/services/freeswitch.cfg" override="false">mvn:${project.groupId}/org.openhab.feature.addons.external/${project.version}/cfg/freeswitch</configfile>
     </feature>
 
     <feature name="openhab2-addon-binding-fs20" description="" version="${project.version}">
@@ -107,19 +107,19 @@
     <feature name="openhab2-addon-binding-heatmiser" description="" version="${project.version}">
         <feature>openhab2-runtime-compat1x</feature>
         <bundle start-level="80">mvn:org.openhab.binding/org.openhab.binding.heatmiser/${oh1.version}</bundle>
-        <configfile finalname="conf/services/heatmiser.cfg" override="false">mvn:${project.groupId}/org.openhab.feature.addons.external/${project.version}/cfg/heatmiser</configfile>
+        <configfile finalname="${openhab.conf}/services/heatmiser.cfg" override="false">mvn:${project.groupId}/org.openhab.feature.addons.external/${project.version}/cfg/heatmiser</configfile>
     </feature>
 
     <feature name="openhab2-addon-binding-homematic" description="" version="${project.version}">
         <feature>openhab2-runtime-compat1x</feature>
         <bundle start-level="80">mvn:org.openhab.binding/org.openhab.binding.homematic/${oh1.version}</bundle>
-        <configfile finalname="conf/services/homematic.cfg" override="false">mvn:${project.groupId}/org.openhab.feature.addons.external/${project.version}/cfg/homematic</configfile>
+        <configfile finalname="${openhab.conf}/services/homematic.cfg" override="false">mvn:${project.groupId}/org.openhab.feature.addons.external/${project.version}/cfg/homematic</configfile>
     </feature>
 
     <feature name="openhab2-addon-binding-http" description="" version="${project.version}">
         <feature>openhab2-runtime-compat1x</feature>
         <bundle start-level="80">mvn:org.openhab.binding/org.openhab.binding.http/${oh1.version}</bundle>
-        <configfile finalname="conf/services/http.cfg" override="false">mvn:${project.groupId}/org.openhab.feature.addons.external/${project.version}/cfg/http</configfile>
+        <configfile finalname="${openhab.conf}/services/http.cfg" override="false">mvn:${project.groupId}/org.openhab.feature.addons.external/${project.version}/cfg/http</configfile>
     </feature>
 
     <feature name="openhab2-addon-binding-hue" description="" version="${project.version}">
@@ -129,14 +129,14 @@
     <feature name="openhab2-addon-binding-ihc" description="" version="${project.version}">
         <feature>openhab2-runtime-compat1x</feature>
         <bundle start-level="80">mvn:org.openhab.binding/org.openhab.binding.ihc/${oh1.version}</bundle>
-        <configfile finalname="conf/services/ihc.cfg" override="false">mvn:${project.groupId}/org.openhab.feature.addons.external/${project.version}/cfg/ihc</configfile>
+        <configfile finalname="${openhab.conf}/services/ihc.cfg" override="false">mvn:${project.groupId}/org.openhab.feature.addons.external/${project.version}/cfg/ihc</configfile>
     </feature>
 
     <feature name="openhab2-addon-binding-insteonplm" description="" version="${project.version}">
         <feature>openhab2-runtime-compat1x</feature>
         <feature>openhab2-addon-transport-serial</feature>
         <bundle start-level="80">mvn:org.openhab.binding/org.openhab.binding.insteonplm/${oh1.version}</bundle>
-        <configfile finalname="conf/services/insteonplm.cfg" override="false">mvn:${project.groupId}/org.openhab.feature.addons.external/${project.version}/cfg/insteonplm</configfile>
+        <configfile finalname="${openhab.conf}/services/insteonplm.cfg" override="false">mvn:${project.groupId}/org.openhab.feature.addons.external/${project.version}/cfg/insteonplm</configfile>
     </feature>
 
     <feature name="openhab2-addon-binding-ipp" description="" version="${project.version}">
@@ -151,7 +151,7 @@
     <feature name="openhab2-addon-binding-knx" description="" version="${project.version}">
         <feature>openhab2-runtime-compat1x</feature>
         <bundle start-level="80">mvn:org.openhab.binding/org.openhab.binding.knx/${oh1.version}</bundle>
-        <configfile finalname="conf/services/knx.cfg" override="false">mvn:${project.groupId}/org.openhab.feature.addons.external/${project.version}/cfg/knx</configfile>
+        <configfile finalname="${openhab.conf}/services/knx.cfg" override="false">mvn:${project.groupId}/org.openhab.feature.addons.external/${project.version}/cfg/knx</configfile>
     </feature>
 
     <feature name="openhab2-addon-binding-lifx" description="" version="${project.version}">
@@ -165,14 +165,14 @@
     <feature name="openhab2-addon-binding-milight" description="" version="${project.version}">
         <feature>openhab2-runtime-compat1x</feature>
         <bundle start-level="80">mvn:org.openhab.binding/org.openhab.binding.milight/${oh1.version}</bundle>
-        <configfile finalname="conf/services/milight.cfg" override="false">mvn:${project.groupId}/org.openhab.feature.addons.external/${project.version}/cfg/milight</configfile>
+        <configfile finalname="${openhab.conf}/services/milight.cfg" override="false">mvn:${project.groupId}/org.openhab.feature.addons.external/${project.version}/cfg/milight</configfile>
     </feature>
 
     <feature name="openhab2-addon-binding-modbus" description="" version="${project.version}">
         <feature>openhab2-runtime-compat1x</feature>
         <feature>openhab2-addon-transport-serial</feature>
         <bundle start-level="80">mvn:org.openhab.binding/org.openhab.binding.modbus/${oh1.version}</bundle>
-        <configfile finalname="conf/services/modbus.cfg" override="false">mvn:${project.groupId}/org.openhab.feature.addons.external/${project.version}/cfg/modbus</configfile>
+        <configfile finalname="${openhab.conf}/services/modbus.cfg" override="false">mvn:${project.groupId}/org.openhab.feature.addons.external/${project.version}/cfg/modbus</configfile>
     </feature>
 
     <feature name="openhab2-addon-binding-network" description="" version="${project.version}">
@@ -182,44 +182,44 @@
     <feature name="openhab2-addon-binding-networkhealth" description="" version="${project.version}">
         <feature>openhab2-runtime-compat1x</feature>
         <bundle start-level="80">mvn:org.openhab.binding/org.openhab.binding.networkhealth/${oh1.version}</bundle>
-        <configfile finalname="conf/services/networkhealth.cfg" override="false">mvn:${project.groupId}/org.openhab.feature.addons.external/${project.version}/cfg/networkhealth</configfile>
+        <configfile finalname="${openhab.conf}/services/networkhealth.cfg" override="false">mvn:${project.groupId}/org.openhab.feature.addons.external/${project.version}/cfg/networkhealth</configfile>
     </feature>
 
     <feature name="openhab2-addon-binding-nibeheatpump" description="" version="${project.version}">
         <feature>openhab2-runtime-compat1x</feature>
         <bundle start-level="80">mvn:org.openhab.binding/org.openhab.binding.nibeheatpump/${oh1.version}</bundle>
-        <configfile finalname="conf/services/nibeheatpump.cfg" override="false">mvn:${project.groupId}/org.openhab.feature.addons.external/${project.version}/cfg/nibeheatpump</configfile>
+        <configfile finalname="${openhab.conf}/services/nibeheatpump.cfg" override="false">mvn:${project.groupId}/org.openhab.feature.addons.external/${project.version}/cfg/nibeheatpump</configfile>
     </feature>
 
     <feature name="openhab2-addon-binding-ntp" description="" version="${project.version}">
         <feature>openhab2-runtime-compat1x</feature>
         <bundle start-level="80">mvn:org.openhab.binding/org.openhab.binding.ntp/${oh1.version}</bundle>
-        <configfile finalname="conf/services/ntp.cfg" override="false">mvn:${project.groupId}/org.openhab.feature.addons.external/${project.version}/cfg/ntp</configfile>
+        <configfile finalname="${openhab.conf}/services/ntp.cfg" override="false">mvn:${project.groupId}/org.openhab.feature.addons.external/${project.version}/cfg/ntp</configfile>
     </feature>
 
     <feature name="openhab2-addon-binding-onkyo" description="" version="${project.version}">
         <feature>openhab2-runtime-compat1x</feature>
         <bundle start-level="80">mvn:org.openhab.binding/org.openhab.binding.onkyo/${oh1.version}</bundle>
-        <configfile finalname="conf/services/onkyo.cfg" override="false">mvn:${project.groupId}/org.openhab.feature.addons.external/${project.version}/cfg/onkyo</configfile>
+        <configfile finalname="${openhab.conf}/services/onkyo.cfg" override="false">mvn:${project.groupId}/org.openhab.feature.addons.external/${project.version}/cfg/onkyo</configfile>
     </feature>
 
     <feature name="openhab2-addon-binding-openenergymonitor" description="" version="${project.version}">
         <feature>openhab2-runtime-compat1x</feature>
         <feature>openhab2-addon-transport-serial</feature>
         <bundle start-level="80">mvn:org.openhab.binding/org.openhab.binding.openenergymonitor/${oh1.version}</bundle>
-        <configfile finalname="conf/services/openenergymonitor.cfg" override="false">mvn:${project.groupId}/org.openhab.feature.addons.external/${project.version}/cfg/openenergymonitor</configfile>
+        <configfile finalname="${openhab.conf}/services/openenergymonitor.cfg" override="false">mvn:${project.groupId}/org.openhab.feature.addons.external/${project.version}/cfg/openenergymonitor</configfile>
     </feature>
 
     <feature name="openhab2-addon-binding-onewire" description="" version="${project.version}">
         <feature>openhab2-runtime-compat1x</feature>
         <bundle start-level="80">mvn:org.openhab.binding/org.openhab.binding.onewire/${oh1.version}</bundle>
-        <configfile finalname="conf/services/onewire.cfg" override="false">mvn:${project.groupId}/org.openhab.feature.addons.external/${project.version}/cfg/onewire</configfile>
+        <configfile finalname="${openhab.conf}/services/onewire.cfg" override="false">mvn:${project.groupId}/org.openhab.feature.addons.external/${project.version}/cfg/onewire</configfile>
     </feature>
 
     <feature name="openhab2-addon-binding-owserver" description="" version="${project.version}">
         <feature>openhab2-runtime-compat1x</feature>
         <bundle start-level="80">mvn:org.openhab.binding/org.openhab.binding.owserver/${oh1.version}</bundle>
-        <configfile finalname="conf/services/owserver.cfg" override="false">mvn:${project.groupId}/org.openhab.feature.addons.external/${project.version}/cfg/owserver</configfile>
+        <configfile finalname="${openhab.conf}/services/owserver.cfg" override="false">mvn:${project.groupId}/org.openhab.feature.addons.external/${project.version}/cfg/owserver</configfile>
     </feature>
 
     <feature name="openhab2-addon-binding-pioneeravr" description="" version="${project.version}">
@@ -240,13 +240,13 @@
     <feature name="openhab2-addon-binding-samsungac" description="" version="${project.version}">
         <feature>openhab2-runtime-compat1x</feature>
         <bundle start-level="80">mvn:org.openhab.binding/org.openhab.binding.samsungac/${oh1.version}</bundle>
-        <configfile finalname="conf/services/samsungac.cfg" override="false">mvn:${project.groupId}/org.openhab.feature.addons.external/${project.version}/cfg/samsungac</configfile>
+        <configfile finalname="${openhab.conf}/services/samsungac.cfg" override="false">mvn:${project.groupId}/org.openhab.feature.addons.external/${project.version}/cfg/samsungac</configfile>
     </feature>
 
     <feature name="openhab2-addon-binding-snmp" description="" version="${project.version}">
         <feature>openhab2-runtime-compat1x</feature>
         <bundle start-level="80">mvn:org.openhab.binding/org.openhab.binding.snmp/${oh1.version}</bundle>
-        <configfile finalname="conf/services/snmp.cfg" override="false">mvn:${project.groupId}/org.openhab.feature.addons.external/${project.version}/cfg/snmp</configfile>
+        <configfile finalname="${openhab.conf}/services/snmp.cfg" override="false">mvn:${project.groupId}/org.openhab.feature.addons.external/${project.version}/cfg/snmp</configfile>
     </feature>
 
     <feature name="openhab2-addon-binding-sonos" description="" version="${project.version}">
@@ -263,13 +263,13 @@
         <feature>openhab2-runtime-compat1x</feature>
         <feature>openhab2-addon-transport-serial</feature>
         <bundle start-level="80">mvn:org.openhab.binding/org.openhab.binding.swegonventilation/${oh1.version}</bundle>
-        <configfile finalname="conf/services/swegonventilation.cfg" override="false">mvn:${project.groupId}/org.openhab.feature.addons.external/${project.version}/cfg/swegonventilation</configfile>
+        <configfile finalname="${openhab.conf}/services/swegonventilation.cfg" override="false">mvn:${project.groupId}/org.openhab.feature.addons.external/${project.version}/cfg/swegonventilation</configfile>
     </feature>
 
     <feature name="openhab2-addon-binding-systeminfo" description="" version="${project.version}">
         <feature>openhab2-runtime-compat1x</feature>
         <bundle start-level="80">mvn:org.openhab.binding/org.openhab.binding.systeminfo/${oh1.version}</bundle>
-        <configfile finalname="conf/services/systeminfo.cfg" override="false">mvn:${project.groupId}/org.openhab.feature.addons.external/${project.version}/cfg/systeminfo</configfile>
+        <configfile finalname="${openhab.conf}/services/systeminfo.cfg" override="false">mvn:${project.groupId}/org.openhab.feature.addons.external/${project.version}/cfg/systeminfo</configfile>
     </feature>
 
     <feature name="openhab2-addon-binding-tellstick" description="" version="${project.version}">
@@ -284,7 +284,7 @@
     <feature name="openhab2-addon-binding-tinkerforge" description="" version="${project.version}">
         <feature>openhab2-runtime-compat1x</feature>
         <bundle start-level="80">mvn:org.openhab.binding/org.openhab.binding.tinkerforge/${oh1.version}</bundle>
-        <configfile finalname="conf/services/tinkerforge.cfg" override="false">mvn:${project.groupId}/org.openhab.feature.addons.external/${project.version}/cfg/tinkerforge</configfile>
+        <configfile finalname="${openhab.conf}/services/tinkerforge.cfg" override="false">mvn:${project.groupId}/org.openhab.feature.addons.external/${project.version}/cfg/tinkerforge</configfile>
     </feature>
 
     <feature name="openhab2-addon-binding-vitotronic" description="" version="${project.version}">
@@ -294,7 +294,7 @@
     <feature name="openhab2-addon-binding-weather" description="" version="${project.version}">
         <feature>openhab2-runtime-compat1x</feature>
         <bundle start-level="80">mvn:org.openhab.binding/org.openhab.binding.weather/${oh1.version}</bundle>
-        <configfile finalname="conf/services/weather.cfg" override="false">mvn:${project.groupId}/org.openhab.feature.addons.external/${project.version}/cfg/weather</configfile>
+        <configfile finalname="${openhab.conf}/services/weather.cfg" override="false">mvn:${project.groupId}/org.openhab.feature.addons.external/${project.version}/cfg/weather</configfile>
     </feature>
 
     <feature name="openhab2-addon-binding-wemo" description="" version="${project.version}">
@@ -319,7 +319,7 @@
         <feature>openhab2-runtime-compat1x</feature>
         <feature>openhab2-addon-transport-serial</feature>
         <bundle start-level="80">mvn:org.openhab.binding/org.openhab.binding.zwave/${oh1.version}</bundle>
-        <configfile finalname="conf/services/zwave.cfg" override="false">mvn:${project.groupId}/org.openhab.feature.addons.external/${project.version}/cfg/zwave</configfile>
+        <configfile finalname="${openhab.conf}/services/zwave.cfg" override="false">mvn:${project.groupId}/org.openhab.feature.addons.external/${project.version}/cfg/zwave</configfile>
     </feature>
 
     <!-- io -->
@@ -334,25 +334,25 @@
     <feature name="openhab2-addon-persistence-rrd4j" description="" version="${project.version}">
         <feature>openhab2-runtime-compat1x</feature>
         <bundle start-level="80">mvn:org.openhab.persistence/org.openhab.persistence.rrd4j/${oh1.version}</bundle>
-        <configfile finalname="conf/services/rrd4j.cfg" override="false">mvn:${project.groupId}/org.openhab.feature.addons.external/${project.version}/cfg/rrd4j</configfile>
+        <configfile finalname="${openhab.conf}/services/rrd4j.cfg" override="false">mvn:${project.groupId}/org.openhab.feature.addons.external/${project.version}/cfg/rrd4j</configfile>
     </feature>
 
     <feature name="openhab2-addon-persistence-mysql" description="" version="${project.version}">
         <feature>openhab2-runtime-compat1x</feature>
         <bundle start-level="80">mvn:org.openhab.persistence/org.openhab.persistence.mysql/${oh1.version}</bundle>
-        <configfile finalname="conf/services/mysql.cfg" override="false">mvn:${project.groupId}/org.openhab.feature.addons.external/${project.version}/cfg/mysql</configfile>
+        <configfile finalname="${openhab.conf}/services/mysql.cfg" override="false">mvn:${project.groupId}/org.openhab.feature.addons.external/${project.version}/cfg/mysql</configfile>
     </feature>
 
     <feature name="openhab2-addon-persistence-logging" description="" version="${project.version}">
         <feature>openhab2-runtime-compat1x</feature>
         <bundle start-level="80">mvn:org.openhab.persistence/org.openhab.persistence.logging/${oh1.version}</bundle>
-        <configfile finalname="conf/services/logging.cfg" override="false">mvn:${project.groupId}/org.openhab.feature.addons.external/${project.version}/cfg/logging</configfile>
+        <configfile finalname="${openhab.conf}/services/logging.cfg" override="false">mvn:${project.groupId}/org.openhab.feature.addons.external/${project.version}/cfg/logging</configfile>
     </feature>
 
     <feature name="openhab2-addon-persistence-jpa" description="" version="${project.version}">
         <feature>openhab2-runtime-compat1x</feature>
         <bundle start-level="80">mvn:org.openhab.persistence/org.openhab.persistence.jpa/${oh1.version}</bundle>
-        <configfile finalname="conf/services/jpa.cfg" override="false">mvn:${project.groupId}/org.openhab.feature.addons.external/${project.version}/cfg/jpa</configfile>
+        <configfile finalname="${openhab.conf}/services/jpa.cfg" override="false">mvn:${project.groupId}/org.openhab.feature.addons.external/${project.version}/cfg/jpa</configfile>
     </feature>
 
     <!-- transport -->
@@ -392,7 +392,7 @@
     <feature name="openhab2-addon-ui-cometvisu" version="${project.version}">
         <feature>openhab2-addon-ui-dashboard</feature>
         <bundle start-level="80">mvn:org.openhab.ui/org.openhab.ui.cometvisu/${project.version}</bundle>
-        <configfile finalname="conf/services/cometvisu.cfg" override="false">mvn:${project.groupId}/org.openhab.feature.addons.external/${project.version}/cfg/cometvisu</configfile>
+        <configfile finalname="${openhab.conf}/services/cometvisu.cfg" override="false">mvn:${project.groupId}/org.openhab.feature.addons.external/${project.version}/cfg/cometvisu</configfile>
     </feature>
 
     <feature name="openhab2-addon-ui-dashboard" version="${project.version}">
@@ -414,7 +414,7 @@
     <feature name="openhab2-addon-marytts" description="" version="${project.version}">
         <feature>openhab2-runtime-compat1x</feature>
         <bundle start-level="80">mvn:org.openhab.io/org.openhab.io.multimedia.tts.marytts/${oh1.version}</bundle>
-        <configfile finalname="conf/services/marytts.cfg" override="false">mvn:${project.groupId}/org.openhab.feature.addons.external/${project.version}/cfg/marytts</configfile>
+        <configfile finalname="${openhab.conf}/services/marytts.cfg" override="false">mvn:${project.groupId}/org.openhab.feature.addons.external/${project.version}/cfg/marytts</configfile>
     </feature>
 
 </features>


### PR DESCRIPTION
This solves: #401

We will need at least Karaf 4.0.2.
I have done the bump in another branch and will submit them as soon as Karaf 4.0.2 is released (currently in staging).

So would prefer to merge this PR as it does not break something and the work is done (magically) if K402 is used.