### PR TITLE
DMX (OLA) added to compatible 1.x Add-ons

### DIFF
--- a/docs/sources/addons.md
+++ b/docs/sources/addons.md
@@ -33,6 +33,7 @@ All optional add-ons for openHAB 2 are [available in a separate download](https:
 | Anel | Binding |
 | Astro | Binding |
 | Denon | Binding |
+| DMX (OLA) | Binding |
 | EDS OWServer | Binding |
 | Energenie | Binding |
 | Enocean | Binding |


### PR DESCRIPTION
DMX 1.7 binding works fine with OH 2