### PR TITLE
Initial contribution of SMA Energy Meter Binding #441

### DIFF
--- a/addons/binding/org.openhab.binding.smaenergymeter/.classpath
+++ b/addons/binding/org.openhab.binding.smaenergymeter/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src/main/java"/>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/addons/binding/org.openhab.binding.smaenergymeter/.project
+++ b/addons/binding/org.openhab.binding.smaenergymeter/.project
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.openhab.binding.smaenergymeter</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ds.core.builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/addons/binding/org.openhab.binding.smaenergymeter/ESH-INF/binding/binding.xml
+++ b/addons/binding/org.openhab.binding.smaenergymeter/ESH-INF/binding/binding.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<binding:binding id="smaenergymeter"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:binding="http://eclipse.org/smarthome/schemas/binding/v1.0.0"
+	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/binding/v1.0.0 http://eclipse.org/smarthome/schemas/binding-1.0.0.xsd">
+
+	<name>SMA Energy Meter Binding</name>
+	<description>Binding for a SMA Energy Meter.</description>
+	<author>Osman Basha</author>
+
+</binding:binding>

--- a/addons/binding/org.openhab.binding.smaenergymeter/ESH-INF/i18n/smaenergymeter_de.properties
+++ b/addons/binding/org.openhab.binding.smaenergymeter/ESH-INF/i18n/smaenergymeter_de.properties
@@ -1,0 +1,18 @@
+# binding
+binding.smaenergymeter.name = SMA Energy Meter Binding
+binding.smaenergymeter.description = Binding für einen SMA Energy Meter.
+
+# thing types
+thing-type.smaenergymeter.energymeter.label = SMA Energy Meter
+thing-type.config.smaenergymeter.energymeter.mcastGroup.label = Multicast-Gruppe
+thing-type.config.smaenergymeter.energymeter.mcastGroup.description = IP-Adresse der Multicast-Gruppe
+thing-type.config.smaenergymeter.energymeter.port.label = Port
+thing-type.config.smaenergymeter.energymeter.port.description = Portnummer der Multicast-Gruppe
+thing-type.config.smaenergymeter.energymeter.pollingPeriod.label = Abfrageintervall
+thing-type.config.smaenergymeter.energymeter.pollingPeriod.description = Daten-Abfrageintervall in Sek.
+
+# channel types
+channel-type.smaenergymeter.powerInType.label = Bezogene Leistung
+channel-type.smaenergymeter.powerOutType.label = Eingespeise Leistung
+channel-type.smaenergymeter.energyInType.label = Bezogene Energie
+channel-type.smaenergymeter.energyOutType.label = Eingespeiste Energie

--- a/addons/binding/org.openhab.binding.smaenergymeter/ESH-INF/thing/energyMeter.xml
+++ b/addons/binding/org.openhab.binding.smaenergymeter/ESH-INF/thing/energyMeter.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thing:thing-descriptions bindingId="smaenergymeter"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:thing="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0"
+	xsi:schemaLocation="http://eclipse.org/smarthome/schemas/thing-description/v1.0.0 http://eclipse.org/smarthome/schemas/thing-description-1.0.0.xsd">
+
+	<thing-type id="energymeter">
+		<label>SMA Energy Meter</label>
+
+		<channels>
+			<channel id="powerIn" typeId="powerInType" />
+			<channel id="powerOut" typeId="powerOutType" />
+			<channel id="energyIn" typeId="energyInType" />
+			<channel id="energyOut" typeId="energyOutType" />
+		</channels>
+
+		<properties>
+			<property name="vendor">Vendor</property>
+			<property name="serialNumber">Serial Number</property>
+		</properties>
+
+		<config-description>
+			<parameter name="mcastGroup" type="text" required="true">
+				<label>Multicast Group</label>
+				<description>IP address of the multicast group</description>
+				<default>239.12.255.254</default>
+			</parameter>
+			<parameter name="port" type="integer" required="false" min="1024"
+				max="49151">
+				<label>Port</label>
+				<description>Port of the multicast group</description>
+				<default>9522</default>
+				<advanced>true</advanced>
+			</parameter>
+			<parameter name="pollingPeriod" type="integer" required="false">
+				<label>Polling period</label>
+				<description>Polling period for refreshing the data in s</description>
+				<default>30</default>
+				<advanced>true</advanced>
+			</parameter>
+		</config-description>
+	</thing-type>
+
+	<channel-type id="powerInType">
+		<item-type>Number</item-type>
+		<label>Purchased power</label>
+		<category>Energy</category>
+		<state pattern="%.2f W" readOnly="true" />
+	</channel-type>
+    <channel-type id="powerOutType">
+        <item-type>Number</item-type>
+        <label>Grid feed-in power</label>
+        <category>Energy</category>
+        <state pattern="%.2f W" readOnly="true" />
+    </channel-type>
+	<channel-type id="energyInType">
+		<item-type>Number</item-type>
+		<label>Purchased energy</label>
+		<category>Energy</category>
+		<state pattern="%.2f kWh" readOnly="true" />
+	</channel-type>
+	<channel-type id="energyOutType">
+		<item-type>Number</item-type>
+		<label>Grid feed-in energy</label>
+		<category>Energy</category>
+		<state pattern="%.2f kWh" readOnly="true" />
+	</channel-type>
+</thing:thing-descriptions>

--- a/addons/binding/org.openhab.binding.smaenergymeter/META-INF/MANIFEST.MF
+++ b/addons/binding/org.openhab.binding.smaenergymeter/META-INF/MANIFEST.MF
@@ -1,0 +1,19 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: SMAEnergyMeter Binding
+Bundle-SymbolicName: org.openhab.binding.smaenergymeter;singleton:=true
+Bundle-Vendor: openHAB
+Bundle-Version: 2.0.0.qualifier
+Bundle-RequiredExecutionEnvironment: JavaSE-1.7
+Bundle-ClassPath: .
+Import-Package: com.google.common.collect,
+ org.eclipse.smarthome.config.core,
+ org.eclipse.smarthome.config.discovery,
+ org.eclipse.smarthome.core.library.types,
+ org.eclipse.smarthome.core.thing,
+ org.eclipse.smarthome.core.thing.binding,
+ org.eclipse.smarthome.core.types,
+ org.slf4j
+Service-Component: OSGI-INF/*
+Export-Package: org.openhab.binding.smaenergymeter,
+ org.openhab.binding.smaenergymeter.handler

--- a/addons/binding/org.openhab.binding.smaenergymeter/OSGI-INF/SMAEnergyMeterDiscovery.xml
+++ b/addons/binding/org.openhab.binding.smaenergymeter/OSGI-INF/SMAEnergyMeterDiscovery.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2014 openHAB UG (haftungsbeschraenkt) and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+-->
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" immediate="true" name="org.openhab.binding.smaenergymeter.discovery.SMAEnergyMeterDiscoveryService">
+
+   <implementation class="org.openhab.binding.smaenergymeter.discovery.SMAEnergyMeterDiscoveryService"/>
+
+   <service>
+      <provide interface="org.eclipse.smarthome.config.discovery.DiscoveryService"/>
+   </service>
+
+</scr:component>

--- a/addons/binding/org.openhab.binding.smaenergymeter/OSGI-INF/SMAEnergyMeterHandlerFactory.xml
+++ b/addons/binding/org.openhab.binding.smaenergymeter/OSGI-INF/SMAEnergyMeterHandlerFactory.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2014 openHAB UG (haftungsbeschraenkt) and others.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+-->
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" immediate="true" name="org.openhab.binding.smaenergymeter.internal.SMAEnergyMeterHandlerFactory">
+
+   <implementation class="org.openhab.binding.smaenergymeter.internal.SMAEnergyMeterHandlerFactory"/>
+
+   <service>
+      <provide interface="org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory"/>
+   </service>
+
+</scr:component>

--- a/addons/binding/org.openhab.binding.smaenergymeter/README.md
+++ b/addons/binding/org.openhab.binding.smaenergymeter/README.md
@@ -1,0 +1,29 @@
+# SMA Energy Meter Binding
+
+This Binding is used to display the measured values of a SMA Energy Meter device. It shows purchased and grid feed-in power and energy.
+
+## Supported Things
+
+This Binding supports SMA Energy Meter devices.
+
+## Discovery
+
+The Energy Meter is discovered by receiving data on the default multicast IP address.
+
+## Binding Configuration
+
+No binding configuration required.
+
+## Thing Configuration
+
+Usually no manual configuration is required, as the multicast IP address and the port remain on their factory set values. Optionally, a refresh interval (in seconds) can be defined.
+
+## Channels
+
+- **powerIn** Purchased power [W]
+- **powerOut** Grid feed-in power [W]
+- **energyIn** Purchased energy [kWh]
+- **energyOut** Grid feed-in energy [kWh]
+
+## Full example
+N/A

--- a/addons/binding/org.openhab.binding.smaenergymeter/build.properties
+++ b/addons/binding/org.openhab.binding.smaenergymeter/build.properties
@@ -1,0 +1,6 @@
+source.. = src/main/java/
+output.. = target/classes
+bin.includes = META-INF/,\
+               .,\
+               OSGI-INF/,\
+               ESH-INF/

--- a/addons/binding/org.openhab.binding.smaenergymeter/pom.xml
+++ b/addons/binding/org.openhab.binding.smaenergymeter/pom.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.openhab.binding</groupId>
+    <artifactId>pom</artifactId>
+    <version>2.0.0-SNAPSHOT</version>
+  </parent>
+
+  <groupId>org.openhab.binding</groupId>
+  <artifactId>org.openhab.binding.smaenergymeter</artifactId>
+  <version>2.0.0-SNAPSHOT</version>
+  
+  <name>SMA EnergyMeter Binding</name>
+  <packaging>eclipse-plugin</packaging>
+
+</project>

--- a/addons/binding/org.openhab.binding.smaenergymeter/src/main/java/org/openhab/binding/smaenergymeter/SMAEnergyMeterBindingConstants.java
+++ b/addons/binding/org.openhab.binding.smaenergymeter/src/main/java/org/openhab/binding/smaenergymeter/SMAEnergyMeterBindingConstants.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2014 openHAB UG (haftungsbeschraenkt) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.smaenergymeter;
+
+import java.util.Collections;
+import java.util.Set;
+
+import org.eclipse.smarthome.core.thing.ThingTypeUID;
+
+/**
+ * The {@link SMAEnergyMeterBinding} class defines common constants, which are
+ * used across the whole binding.
+ *
+ * @author Osman Basha - Initial contribution
+ */
+public class SMAEnergyMeterBindingConstants {
+
+    public static final String BINDING_ID = "smaenergymeter";
+
+    // List of all Thing Type UIDs
+    public final static ThingTypeUID THING_TYPE_ENERGY_METER = new ThingTypeUID(BINDING_ID, "energymeter");
+
+    public final static Set<ThingTypeUID> SUPPORTED_THING_TYPES_UIDS = Collections.singleton(THING_TYPE_ENERGY_METER);
+
+    // List of all Channel IDs
+    public final static String CHANNEL_POWER_IN = "powerIn";
+    public final static String CHANNEL_POWER_OUT = "powerOut";
+    public final static String CHANNEL_ENERGY_IN = "energyIn";
+    public final static String CHANNEL_ENERGY_OUT = "energyOut";
+
+}

--- a/addons/binding/org.openhab.binding.smaenergymeter/src/main/java/org/openhab/binding/smaenergymeter/configuration/EnergyMeterConfig.java
+++ b/addons/binding/org.openhab.binding.smaenergymeter/src/main/java/org/openhab/binding/smaenergymeter/configuration/EnergyMeterConfig.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2014 openHAB UG (haftungsbeschraenkt) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.smaenergymeter.configuration;
+
+/**
+ * The {@link EnergyMeterConfig} class holds the configuration properties of the binding.
+ *
+ * @author Osman Basha - Initial contribution
+ */
+public class EnergyMeterConfig {
+
+    private String mcastGroup;
+    private Integer port;
+    private Integer pollingPeriod;
+
+    public String getMcastGroup() {
+        return mcastGroup;
+    }
+
+    public void setMcastGroup(String mcastGroup) {
+        this.mcastGroup = mcastGroup;
+    }
+
+    public Integer getPort() {
+        return port;
+    }
+
+    public void setPort(Integer port) {
+        this.port = port;
+    }
+
+    public Integer getPollingPeriod() {
+        return pollingPeriod;
+    }
+
+    public void setPollingPeriod(Integer pollingPeriod) {
+        this.pollingPeriod = pollingPeriod;
+    }
+
+}

--- a/addons/binding/org.openhab.binding.smaenergymeter/src/main/java/org/openhab/binding/smaenergymeter/discovery/SMAEnergyMeterDiscoveryService.java
+++ b/addons/binding/org.openhab.binding.smaenergymeter/src/main/java/org/openhab/binding/smaenergymeter/discovery/SMAEnergyMeterDiscoveryService.java
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) 2014 openHAB UG (haftungsbeschraenkt) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.smaenergymeter.discovery;
+
+import static org.openhab.binding.smaenergymeter.SMAEnergyMeterBindingConstants.*;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.smarthome.config.discovery.AbstractDiscoveryService;
+import org.eclipse.smarthome.config.discovery.DiscoveryResult;
+import org.eclipse.smarthome.config.discovery.DiscoveryResultBuilder;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.ThingTypeUID;
+import org.eclipse.smarthome.core.thing.ThingUID;
+import org.openhab.binding.smaenergymeter.handler.EnergyMeter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link SMAEnergyMeterDiscoveryService} class implements a service
+ * for discovering the SMA Energy Meter.
+ *
+ * @author Osman Basha - Initial contribution
+ */
+public class SMAEnergyMeterDiscoveryService extends AbstractDiscoveryService {
+
+    private final static Logger logger = LoggerFactory.getLogger(SMAEnergyMeterDiscoveryService.class);
+
+    public SMAEnergyMeterDiscoveryService() {
+        super(SUPPORTED_THING_TYPES_UIDS, 15, true);
+    }
+
+    @Override
+    public Set<ThingTypeUID> getSupportedThingTypes() {
+        return SUPPORTED_THING_TYPES_UIDS;
+    }
+
+    @Override
+    protected void startBackgroundDiscovery() {
+        logger.debug("Start SMAEnergyMeter background discovery");
+        scheduler.schedule(new Runnable() {
+            @Override
+            public void run() {
+                discover();
+            }
+        }, 0, TimeUnit.SECONDS);
+    }
+
+    @Override
+    public void startScan() {
+        logger.debug("Start SMAEnergyMeter scan");
+        discover();
+    }
+
+    private synchronized void discover() {
+        logger.debug("Try to discover a SMA Energy Meter device");
+
+        EnergyMeter energyMeter = new EnergyMeter(EnergyMeter.DEFAULT_MCAST_GRP, EnergyMeter.DEFAULT_MCAST_PORT);
+        try {
+            energyMeter.update();
+        } catch (IOException e) {
+            logger.debug("No SMA Energy Meter found.");
+            logger.debug("Diagnostic: ", e);
+            return;
+        }
+
+        logger.debug("Adding a new SMA Engergy Meter with S/N '{}' to inbox", energyMeter.getSerialNumber());
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(Thing.PROPERTY_VENDOR, "SMA");
+        properties.put(Thing.PROPERTY_SERIAL_NUMBER, energyMeter.getSerialNumber());
+        ThingUID uid = new ThingUID(THING_TYPE_ENERGY_METER, energyMeter.getSerialNumber());
+        if (uid != null) {
+            DiscoveryResult result = DiscoveryResultBuilder.create(uid).withProperties(properties)
+                    .withLabel("SMA Energy Meter").build();
+            thingDiscovered(result);
+
+            logger.debug("Thing discovered '{}'", result);
+        }
+    }
+
+}

--- a/addons/binding/org.openhab.binding.smaenergymeter/src/main/java/org/openhab/binding/smaenergymeter/handler/EnergyMeter.java
+++ b/addons/binding/org.openhab.binding.smaenergymeter/src/main/java/org/openhab/binding/smaenergymeter/handler/EnergyMeter.java
@@ -1,0 +1,105 @@
+/**
+ * Copyright (c) 2014 openHAB UG (haftungsbeschraenkt) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.smaenergymeter.handler;
+
+import java.io.IOException;
+import java.net.DatagramPacket;
+import java.net.InetAddress;
+import java.net.MulticastSocket;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Date;
+
+import org.eclipse.smarthome.core.library.types.DecimalType;
+
+/**
+ * The {@link EnergyMeter} class is responsible for communication with the SMA device
+ * and extracting the data fields out of the received telegrams.
+ *
+ * @author Osman Basha - Initial contribution
+ */
+public class EnergyMeter {
+
+    private String multicastGroup;
+    private int port;
+
+    private String serialNumber;
+    private Date lastUpdate;
+
+    private final FieldDTO powerIn;
+    private final FieldDTO energyIn;
+    private final FieldDTO powerOut;
+    private final FieldDTO energyOut;
+
+    public static final String DEFAULT_MCAST_GRP = "239.12.255.254";
+    public static final int DEFAULT_MCAST_PORT = 9522;
+
+    public EnergyMeter(String multicastGroup, int port) {
+        this.multicastGroup = multicastGroup;
+        this.port = port;
+
+        powerIn = new FieldDTO(0x20, 4, 10);
+        energyIn = new FieldDTO(0x28, 8, 3600000);
+        powerOut = new FieldDTO(0x34, 4, 10);
+        energyOut = new FieldDTO(0x3C, 8, 3600000);
+    }
+
+    public void update() throws IOException {
+        byte[] bytes = new byte[600];
+        try (MulticastSocket socket = new MulticastSocket(port)) {
+            socket.setSoTimeout(5000);
+            InetAddress address = InetAddress.getByName(multicastGroup);
+            socket.joinGroup(address);
+
+            DatagramPacket msgPacket = new DatagramPacket(bytes, bytes.length);
+            socket.receive(msgPacket);
+
+            String sma = new String(Arrays.copyOfRange(bytes, 0x00, 0x03));
+            if (!sma.equals("SMA")) {
+                throw new IOException("Not a SMA telegram." + sma);
+            }
+
+            ByteBuffer buffer = ByteBuffer.wrap(Arrays.copyOfRange(bytes, 0x14, 0x18));
+            serialNumber = String.valueOf(buffer.getInt());
+
+            powerIn.updateValue(bytes);
+            energyIn.updateValue(bytes);
+            powerOut.updateValue(bytes);
+            energyOut.updateValue(bytes);
+
+            lastUpdate = new Date(System.currentTimeMillis());
+        } catch (Exception e) {
+            throw new IOException(e);
+        }
+    }
+
+    public String getSerialNumber() {
+        return serialNumber;
+    }
+
+    public Date getLastUpdate() {
+        return lastUpdate;
+    }
+
+    public DecimalType getPowerIn() {
+        return new DecimalType(powerIn.getValue());
+    }
+
+    public DecimalType getPowerOut() {
+        return new DecimalType(powerOut.getValue());
+    }
+
+    public DecimalType getEnergyIn() {
+        return new DecimalType(energyIn.getValue());
+    }
+
+    public DecimalType getEnergyOut() {
+        return new DecimalType(energyOut.getValue());
+    }
+
+}

--- a/addons/binding/org.openhab.binding.smaenergymeter/src/main/java/org/openhab/binding/smaenergymeter/handler/FieldDTO.java
+++ b/addons/binding/org.openhab.binding.smaenergymeter/src/main/java/org/openhab/binding/smaenergymeter/handler/FieldDTO.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2014 openHAB UG (haftungsbeschraenkt) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.smaenergymeter.handler;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+
+/**
+ * The {@link FieldDTO} class holds the data for a single field (i.e. the power purchased).
+ *
+ * @author Osman Basha - Initial contribution
+ */
+public class FieldDTO {
+
+    private final int address;
+    private final int length;
+    private final int divisor;
+    private float value;
+
+    public FieldDTO(int address, int length, int divisor) {
+        this.address = address;
+        if ((length != 4) && (length != 8)) {
+            throw new IllegalArgumentException("length should be 4 or 8 bytes");
+        }
+        this.length = length;
+        this.divisor = divisor;
+    }
+
+    public float getValue() {
+        return value;
+    }
+
+    public void updateValue(byte[] bytes) {
+        if (length == 4) {
+            value = (float) bytesToUInt16(Arrays.copyOfRange(bytes, address, address + 4)) / divisor;
+        } else {
+            value = (float) bytesToUInt32(Arrays.copyOfRange(bytes, address, address + 8)) / divisor;
+        }
+    }
+
+    private int bytesToUInt16(byte[] bytes) {
+        ByteBuffer buffer = ByteBuffer.wrap(bytes);
+        return buffer.getInt();
+    }
+
+    private long bytesToUInt32(byte[] bytes) {
+        ByteBuffer buffer = ByteBuffer.wrap(bytes);
+        return buffer.getLong();
+    }
+
+}

--- a/addons/binding/org.openhab.binding.smaenergymeter/src/main/java/org/openhab/binding/smaenergymeter/handler/SMAEnergyMeterHandler.java
+++ b/addons/binding/org.openhab.binding.smaenergymeter/src/main/java/org/openhab/binding/smaenergymeter/handler/SMAEnergyMeterHandler.java
@@ -1,0 +1,114 @@
+/**
+ * Copyright (c) 2014 openHAB UG (haftungsbeschraenkt) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.smaenergymeter.handler;
+
+import static org.openhab.binding.smaenergymeter.SMAEnergyMeterBindingConstants.*;
+
+import java.io.IOException;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.smarthome.core.thing.ChannelUID;
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.ThingStatus;
+import org.eclipse.smarthome.core.thing.ThingStatusDetail;
+import org.eclipse.smarthome.core.thing.binding.BaseThingHandler;
+import org.eclipse.smarthome.core.types.Command;
+import org.eclipse.smarthome.core.types.RefreshType;
+import org.openhab.binding.smaenergymeter.configuration.EnergyMeterConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The {@link SMAEnergyMeterHandler} is responsible for handling commands, which are
+ * sent to one of the channels.
+ *
+ * @author Osman Basha - Initial contribution
+ */
+public class SMAEnergyMeterHandler extends BaseThingHandler {
+
+    private Logger logger = LoggerFactory.getLogger(SMAEnergyMeterHandler.class);
+    private EnergyMeter energyMeter;
+    private ScheduledFuture<?> pollingJob;
+
+    public SMAEnergyMeterHandler(Thing thing) {
+        super(thing);
+    }
+
+    @Override
+    public void handleCommand(ChannelUID channelUID, Command command) {
+        if (command == RefreshType.REFRESH) {
+            logger.debug("Refreshing {}", channelUID);
+            updateData();
+        } else {
+            logger.warn("This binding is a read-only binding and cannot handle commands");
+        }
+    }
+
+    @Override
+    public void initialize() {
+        logger.debug("Initializing SMAEnergyMeter handler '{}'", getThing().getUID());
+
+        EnergyMeterConfig config = getConfigAs(EnergyMeterConfig.class);
+
+        int port = (config.getPort() == null) ? EnergyMeter.DEFAULT_MCAST_PORT : config.getPort();
+        energyMeter = new EnergyMeter(config.getMcastGroup(), port);
+        try {
+            energyMeter.update();
+
+            updateProperty(Thing.PROPERTY_VENDOR, "SMA");
+            updateProperty(Thing.PROPERTY_SERIAL_NUMBER, energyMeter.getSerialNumber());
+            logger.debug("Found a SMA Energy Meter with S/N '{}'", energyMeter.getSerialNumber());
+        } catch (IOException e) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.OFFLINE.CONFIGURATION_ERROR, e.getMessage());
+            return;
+        }
+
+        int pollingPeriod = (config.getPollingPeriod() == null) ? 30 : config.getPollingPeriod();
+        pollingJob = scheduler.scheduleWithFixedDelay(new Runnable() {
+            @Override
+            public void run() {
+                updateData();
+            }
+        }, 0, pollingPeriod, TimeUnit.SECONDS);
+        logger.debug("Polling job scheduled to run every {} sec. for '{}'", pollingPeriod, getThing().getUID());
+
+        updateStatus(ThingStatus.ONLINE);
+    }
+
+    @Override
+    public void dispose() {
+        logger.debug("Disposing SMAEnergyMeter handler '{}'", getThing().getUID());
+
+        if (pollingJob != null) {
+            pollingJob.cancel(true);
+            pollingJob = null;
+        }
+        energyMeter = null;
+    }
+
+    private synchronized void updateData() {
+        logger.debug("Update SMAEnergyMeter data '{}'", getThing().getUID());
+
+        try {
+            energyMeter.update();
+
+            updateState(CHANNEL_POWER_IN, energyMeter.getPowerIn());
+            updateState(CHANNEL_POWER_OUT, energyMeter.getPowerOut());
+            updateState(CHANNEL_ENERGY_IN, energyMeter.getEnergyIn());
+            updateState(CHANNEL_ENERGY_OUT, energyMeter.getEnergyOut());
+
+            if (getThing().getStatus().equals(ThingStatus.OFFLINE)) {
+                updateStatus(ThingStatus.ONLINE);
+            }
+        } catch (IOException e) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.OFFLINE.COMMUNICATION_ERROR, e.getMessage());
+        }
+    }
+
+}

--- a/addons/binding/org.openhab.binding.smaenergymeter/src/main/java/org/openhab/binding/smaenergymeter/internal/SMAEnergyMeterHandlerFactory.java
+++ b/addons/binding/org.openhab.binding.smaenergymeter/src/main/java/org/openhab/binding/smaenergymeter/internal/SMAEnergyMeterHandlerFactory.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2014 openHAB UG (haftungsbeschraenkt) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.openhab.binding.smaenergymeter.internal;
+
+import static org.openhab.binding.smaenergymeter.SMAEnergyMeterBindingConstants.*;
+
+import org.eclipse.smarthome.core.thing.Thing;
+import org.eclipse.smarthome.core.thing.ThingTypeUID;
+import org.eclipse.smarthome.core.thing.binding.BaseThingHandlerFactory;
+import org.eclipse.smarthome.core.thing.binding.ThingHandler;
+import org.openhab.binding.smaenergymeter.handler.SMAEnergyMeterHandler;
+
+/**
+ * The {@link SMAEnergyMeterHandlerFactory} is responsible for creating things and thing
+ * handlers.
+ *
+ * @author Osman Basha - Initial contribution
+ */
+public class SMAEnergyMeterHandlerFactory extends BaseThingHandlerFactory {
+
+    @Override
+    public boolean supportsThingType(ThingTypeUID thingTypeUID) {
+        return SUPPORTED_THING_TYPES_UIDS.contains(thingTypeUID);
+    }
+
+    @Override
+    protected ThingHandler createHandler(Thing thing) {
+
+        ThingTypeUID thingTypeUID = thing.getThingTypeUID();
+
+        if (thingTypeUID.equals(THING_TYPE_ENERGY_METER)) {
+            return new SMAEnergyMeterHandler(thing);
+        }
+
+        return null;
+    }
+
+}

--- a/addons/binding/pom.xml
+++ b/addons/binding/pom.xml
@@ -28,6 +28,7 @@
     <module>org.openhab.binding.network</module>
     <module>org.openhab.binding.pioneeravr</module>
     <module>org.openhab.binding.pulseaudio</module>
+    <module>org.openhab.binding.smaenergymeter</module>
     <module>org.openhab.binding.sonos</module>
     <module>org.openhab.binding.squeezebox</module>
     <module>org.openhab.binding.tesla</module>


### PR DESCRIPTION
This is a new binding for a SMA Energy Meter showing purchased and grid feed-in power and energy. It supports automatic discovery. Contains German translation. I've tested it in my home environment. 

Signed-off-by: Osman Basha <osman@basha.at> (github: github_handle)
