### PR TITLE
inclusion op OH2 version of NTP binding

### DIFF
--- a/distribution/openhabhome/conf/items/demo.items
+++ b/distribution/openhabhome/conf/items/demo.items
@@ -103,7 +103,7 @@ DateTime Weather_LastUpdate		"Last Update [%1$ta %1$tR]"	<clock>
 Number  Sun_Elevation           "Sun Elevation"             <sun>        (Weather)   { channel="astro:sun:home:position#elevation" }
 
 /* Demo items */
-DateTime CurrentDate			"Date [%1$tA, %1$td.%1$tm.%1$tY]"	<calendar>	{ ntp="Europe/Berlin:de_DE" }
+DateTime CurrentDate			"Date [%1$tA, %1$td.%1$tm.%1$tY]"	<calendar>	{ channel="ntp:ntp:demo:dateTime" }
 Switch DemoSwitch				"Switch"
 Dimmer DimmedLight				"Dimmer [%d %%]"		<slider>
 Color  RGBLight					"RGB Light"				<slider>

--- a/distribution/openhabhome/conf/things/demo.things
+++ b/distribution/openhabhome/conf/things/demo.things
@@ -1,2 +1,3 @@
 yahooweather:weather:berlin [ location="638242" ]
 astro:sun:home  [ geolocation="52.5200066,13.4049540", interval=60 ]
+ntp:ntp:demo [ ntpServer="nl.pool.ntp.org", refreshInterval=60, refreshNtp=30 ]

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -162,6 +162,11 @@
             <artifactId>org.eclipse.smarthome.binding.lifx</artifactId>
             <version>${esh.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.smarthome.binding</groupId>
+            <artifactId>org.eclipse.smarthome.binding.ntp</artifactId>
+            <version>${esh.version}</version>
+        </dependency>
 
         <!-- openHAB 1 add-ons to include -->
         <dependency>
@@ -262,11 +267,6 @@
         <dependency>
             <groupId>org.openhab.binding</groupId>
             <artifactId>org.openhab.binding.nibeheatpump</artifactId>
-            <version>${oh1.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.openhab.binding</groupId>
-            <artifactId>org.openhab.binding.ntp</artifactId>
             <version>${oh1.version}</version>
         </dependency>
         <dependency>

--- a/distribution/src/assemble/demo.xml
+++ b/distribution/src/assemble/demo.xml
@@ -77,13 +77,13 @@
       	<include>org.eclipse.smarthome.binding:org.eclipse.smarthome.binding.yahooweather:jar:*</include>
       	<include>org.eclipse.smarthome.binding:org.eclipse.smarthome.binding.wemo:jar:*</include>
       	<include>org.eclipse.smarthome.binding:org.eclipse.smarthome.binding.hue:jar:*</include>
+      	<include>org.eclipse.smarthome.binding:org.eclipse.smarthome.binding.ntp:jar:*</include>
       	<include>org.openhab.binding:org.openhab.binding.sonos:jar:*</include>
       	<include>org.openhab.binding:org.openhab.binding.ipp:jar:*</include>
       	<include>org.openhab.binding:org.openhab.binding.astro:jar:*</include>
       	<include>org.openhab.binding:org.openhab.binding.avmfritz:jar:*</include>      	
 		<!-- 1.x addons -->
       	<include>org.openhab.persistence:org.openhab.persistence.rrd4j:jar:*</include>
-      	<include>org.openhab.binding:org.openhab.binding.ntp:jar:*</include>
       </includes>
     </dependencySet>
   </dependencySets>


### PR DESCRIPTION
inclusion op OH2 version of NTP binding in the regular distribution
Updated demo files to use the OH2 version of the ntp binding

Pls merge https://github.com/eclipse/smarthome/pull/504 prior to this one.

Signed-off-by: Marcel Verpaalen <marcel@verpaalen.com>