### PR TITLE
configured log4j to resemble openHAB 1 logs

### DIFF
--- a/distributions/openhab-runtime-karaf/src/main/resources/etc/org.apache.karaf.log.cfg
+++ b/distributions/openhab-runtime-karaf/src/main/resources/etc/org.apache.karaf.log.cfg
@@ -1,0 +1,36 @@
+################################################################################
+#
+#    Licensed to the Apache Software Foundation (ASF) under one or more
+#    contributor license agreements.  See the NOTICE file distributed with
+#    this work for additional information regarding copyright ownership.
+#    The ASF licenses this file to You under the Apache License, Version 2.0
+#    (the "License"); you may not use this file except in compliance with
+#    the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+################################################################################
+
+#
+# This configuration file is used to configure the default values for the log:display
+# and log:exception-display commands.
+#
+
+#
+# The number of log statements to be displayed using log:display. It also defines the number
+# of lines searched for exceptions using log:exception-display. You can override this value
+# at runtime using -n in log:display.
+#
+size = 500
+
+#
+# The pattern used to format the log statement when using log:display. This pattern is according
+# to the log4j layout. You can override this parameter at runtime using log:display with -p.
+#
+pattern = %d{HH:mm:ss.SSS} [%-5.5p] [%-36.36c] - %m%n

--- a/distributions/openhab-runtime-karaf/src/main/resources/etc/org.ops4j.pax.logging.cfg
+++ b/distributions/openhab-runtime-karaf/src/main/resources/etc/org.ops4j.pax.logging.cfg
@@ -1,0 +1,63 @@
+################################################################################
+#
+#    Licensed to the Apache Software Foundation (ASF) under one or more
+#    contributor license agreements.  See the NOTICE file distributed with
+#    this work for additional information regarding copyright ownership.
+#    The ASF licenses this file to You under the Apache License, Version 2.0
+#    (the "License"); you may not use this file except in compliance with
+#    the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+################################################################################
+
+# Root logger
+log4j.rootLogger = WARN, out, osgi:*
+log4j.throwableRenderer=org.apache.log4j.OsgiThrowableRenderer
+
+# openHAB specific logger
+log4j.logger.smarthome.event=INFO, event, osgi:*
+
+log4j.logger.org.openhab=INFO
+log4j.logger.org.eclipse.smarthome=INFO
+log4j.logger.org.jupnp = ERROR
+
+
+# CONSOLE appender not used by default
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{HH:mm:ss.SSS} [%-5.5p] [%-36.36c] - %m%n
+
+# File appender - openhab.log
+log4j.appender.out=org.apache.log4j.RollingFileAppender
+log4j.appender.out.layout=org.apache.log4j.PatternLayout
+log4j.appender.out.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss.SSS} [%-5.5p] [%-36.36c] - %m%n
+log4j.appender.out.file=${karaf.data}/logs/openhab.log
+log4j.appender.out.append=true
+log4j.appender.out.maxFileSize=10MB
+log4j.appender.out.maxBackupIndex=10
+
+# File appender - events.log
+log4j.appender.event=org.apache.log4j.RollingFileAppender
+log4j.appender.event.layout=org.apache.log4j.PatternLayout
+log4j.appender.event.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss.SSS} [%-15.15c{1}] - %m%n
+log4j.appender.event.file=${karaf.data}/logs/events.log
+log4j.appender.event.append=true
+log4j.appender.event.maxFileSize=10MB
+log4j.appender.event.maxBackupIndex=10
+
+# Sift appender
+log4j.appender.sift=org.apache.log4j.sift.MDCSiftingAppender
+log4j.appender.sift.key=bundle.name
+log4j.appender.sift.default=openhab
+log4j.appender.sift.appender=org.apache.log4j.FileAppender
+log4j.appender.sift.appender.layout=org.apache.log4j.PatternLayout
+log4j.appender.sift.appender.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss.SSS} [%-5.5p] [%-36.36c] - %m%n
+log4j.appender.sift.appender.file=${karaf.data}/logs/$\\{bundle.name\\}.log
+log4j.appender.sift.appender.append=true


### PR DESCRIPTION
Signed-off-by: Kai Kreuzer <kai@openhab.org>