### PR TITLE
drop rfxcom OH1 in favor of OH2 one

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -326,11 +326,6 @@
         </dependency>
         <dependency>
             <groupId>org.openhab.binding</groupId>
-            <artifactId>org.openhab.binding.rfxcom</artifactId>
-            <version>${oh1.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.openhab.binding</groupId>
             <artifactId>org.openhab.binding.satel</artifactId>
             <version>${oh1.version}</version>
         </dependency>


### PR DESCRIPTION
Fix #469 