### PR TITLE
fix redundant DS packaging instruction

### DIFF
--- a/bundles/io/org.openhab.io.rest.docs/build.properties
+++ b/bundles/io/org.openhab.io.rest.docs/build.properties
@@ -1,6 +1,5 @@
 bin.includes = META-INF/,\
                .,\
                OSGI-INF/,\
-               swagger/,\
-               OSGI-INF/dashboardtile.xml
+               swagger/
 source.. = src/main/java


### PR DESCRIPTION
As long as the whole directory is included, we do not need to include
files of that directory separatly.