### PR TITLE
mark servlet registration to be done immediately

### DIFF
--- a/bundles/io/org.openhab.io.rest.docs/OSGI-INF/dashboardtile.xml
+++ b/bundles/io/org.openhab.io.rest.docs/OSGI-INF/dashboardtile.xml
@@ -9,7 +9,7 @@
     http://www.eclipse.org/legal/epl-v10.html
 
 -->
-<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" name="org.openhab.io.rest.docs.dashboardtile">
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" immediate="true" name="org.openhab.io.rest.docs.dashboardtile">
    <implementation class="org.openhab.io.rest.docs.internal.RESTDashboardTile"/>
    <service>
       <provide interface="org.openhab.ui.dashboard.DashboardTile"/>


### PR DESCRIPTION
The servlet (alias '/doc') component is enabled when started, but not
marked to be activated immediately.
This result in an activate, deactivate, activate.
This is done such fast, that the deregistration of the alias is not
finished (I assume async cleanup) for the second activate.

Signed-off-by: Markus Rathgeb <maggu2810@gmail.com>