### PR TITLE
GC + EventAdmin thread count update (#514)

### DIFF
--- a/distributions/openhab-runtime-karaf/src/main/resources/bin/setenv
+++ b/distributions/openhab-runtime-karaf/src/main/resources/bin/setenv
@@ -40,7 +40,6 @@
 # export JAVA_MAX_MEM # Maximum memory for the JVM
 # export JAVA_PERM_MEM # Minimum perm memory for the JVM
 # export JAVA_MAX_PERM_MEM # Maximum perm memory for the JVM
-# export EXTRA_JAVA_OPTS # Additional JVM options
 # export KARAF_HOME # Karaf home folder
 # export KARAF_DATA # Karaf data folder
 # export KARAF_BASE # Karaf base folder
@@ -80,3 +79,9 @@ export JAVA_OPTS="${JAVA_OPTS}
   -Dopenhab.userdata=${OPENHAB_USERDATA}
   -Dorg.osgi.service.http.port=${HTTP_PORT}
   -Dorg.osgi.service.http.port.secure=${HTTPS_PORT}"
+
+#
+# set jvm options
+#
+
+export EXTRA_JAVA_OPTS=-XX:+UseG1GC

--- a/distributions/openhab-runtime-karaf/src/main/resources/bin/setenv.bat
+++ b/distributions/openhab-runtime-karaf/src/main/resources/bin/setenv.bat
@@ -48,8 +48,6 @@ rem Minimum perm memory for the JVM
 rem SET JAVA_PERM_MEM
 rem Maximum perm memory for the JVM
 rem SET JAVA_MAX_PERM_MEM
-rem Additional JVM options
-rem SET EXTRA_JAVA_OPTS
 rem Karaf home folder
 rem SET KARAF_HOME
 rem Karaf data folder
@@ -98,3 +96,5 @@ set JAVA_OPTS=%JAVA_OPTS% ^
   -Dorg.osgi.service.http.port=%HTTP_PORT% ^
   -Dorg.osgi.service.http.port.secure=%HTTPS_PORT%
 
+:: set jvm options
+set EXTRA_JAVA_OPTS=-XX:+UseG1GC

--- a/distributions/openhab-runtime-karaf/src/main/resources/etc/org.apache.felix.eventadmin.impl.EventAdmin.cfg
+++ b/distributions/openhab-runtime-karaf/src/main/resources/etc/org.apache.felix.eventadmin.impl.EventAdmin.cfg
@@ -1,0 +1,5 @@
+# Configure thread pool size for EventAdmin sync event delivery.
+org.apache.felix.eventadmin.ThreadPoolSize=3
+
+# Use as many threads for async as for sync.
+org.apache.felix.eventadmin.AsyncToSyncThreadRatio=1


### PR DESCRIPTION
Switched garbage collector to G1 to reduce memory consumption.
Limited EventAdmin thread pool to 6 (3 sync + 3 async).

Signed-off-by: Davy Vanherbergen <davy.vanherbergen@gmail.com>