### PR TITLE
add paper and basic ui to the normal runtime

### DIFF
--- a/features/org.openhab.feature.runtime/src/main/feature/feature.xml
+++ b/features/org.openhab.feature.runtime/src/main/feature/feature.xml
@@ -5,6 +5,8 @@
         <details>${project.description}</details>
         <feature>openhab-runtime-base</feature>
         <feature>openhab-ui-dashboard</feature>
+        <feature>openhab-ui-basic</feature>
+        <feature>openhab-ui-paper</feature>
         <feature>openhab-misc-restdocs</feature>
         <feature>openhab-misc-certificate</feature>
     </feature>


### PR DESCRIPTION
Bug: https://github.com/openhab/openhab2/issues/532
Signed-off-by: Markus Rathgeb <maggu2810@gmail.com>