### PR TITLE
bump shk and swagger bugfix

### DIFF
--- a/features/org.openhab.feature.aggregate.xml/pom.xml
+++ b/features/org.openhab.feature.aggregate.xml/pom.xml
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>de.maggu2810.playground.shk</groupId>
             <artifactId>shk-feature-base</artifactId>
-            <version>1.0.2-SNAPSHOT</version>
+            <version>1.0.3</version>
             <classifier>features</classifier>
             <type>xml</type>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -147,18 +147,26 @@
             <url>https://jcenter.bintray.com/</url>
         </repository>
         <repository>
-            <!-- TODO: temporary solution as long there is no maven repo for 3rd party libs -->
-            <id>github-openhab2-mvn-repo</id>
-            <name>Git repo for OH2 3rd party libs</name>
-            <url>https://github.com/maggu2810/openhab2-mvn-repo/raw/master/</url>
-        </repository>
-        <repository>
             <id>eclipse</id>
             <name>Eclipse Snapshot Repository</name>
             <layout>default</layout>
             <url>https://repo.eclipse.org/content/repositories/snapshots/</url>
             <snapshots>
                 <enabled>true</enabled>
+            </snapshots>
+        </repository>
+        <repository>
+           <id>tmp-jaxrs-swagger</id>
+           <url>https://github.com/maggu2810/openhab2-mvn-repo/raw/jaxrs-swagger</url>
+           <snapshots>
+              <enabled>true</enabled>
+            </snapshots>
+        </repository>
+        <repository>
+           <id>tmp-shk</id>
+           <url>https://github.com/maggu2810/openhab2-mvn-repo/raw/shk</url>
+           <snapshots>
+              <enabled>true</enabled>
             </snapshots>
         </repository>
     </repositories>


### PR DESCRIPTION
* I turned off the bundling of slf4j in the swagger-all bundle (related to https://github.com/openhab/openhab2/issues/549#issue-122086434)
* Bump shk to get automation and transform features (pre-requirement for #559)