### PR TITLE
Add milliseconds to log timing

### DIFF
--- a/distribution/openhabhome/runtime/etc/logback_debug.xml
+++ b/distribution/openhabhome/runtime/etc/logback_debug.xml
@@ -2,14 +2,14 @@
 
 	<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
 		<encoder>
-			<pattern>%d{yyyy-MM-dd HH:mm:ss} [%-5level] [%-30.30logger{36}:%-5line] - %msg%ex{10}%n</pattern>
+			<pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%-5level] [%-30.30logger{36}:%-5line] - %msg%ex{10}%n</pattern>
 		</encoder>
 	</appender>
 
 	<appender name="FILE" class="ch.qos.logback.core.FileAppender">
 		<file>${openhab.logdir:-userdata/logs}/openhab.log</file>
 		<encoder>
-			<pattern>%d{yyyy-MM-dd HH:mm:ss} [%-5level] [%-30.30logger{36}:%-5line] - %msg%ex{10}%n</pattern>
+			<pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%-5level] [%-30.30logger{36}:%-5line] - %msg%ex{10}%n</pattern>
 		</encoder>
 	</appender>
 


### PR DESCRIPTION
When developing anything time critical, milliseconds is a necessity - otherwise, an change in 1 second in the log could be interpreted anywhere from 1ms to 1999ms difference.
This already seems to be in the ESH and OH2 non-debug configurations
Signed-off-by: Chris Jackson <chris@cd-jackson.com>