### PR TITLE
Document v1.x MQTT binding compatability

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -317,6 +317,11 @@
         </dependency>
         <dependency>
             <groupId>org.openhab.binding</groupId>
+            <artifactId>org.openhab.binding.mqtt</artifactId>
+            <version>${oh1.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.openhab.binding</groupId>
             <artifactId>org.openhab.binding.networkhealth</artifactId>
             <version>${oh1.version}</version>
         </dependency>
@@ -467,7 +472,12 @@
             <groupId>org.openhab.io</groupId>
             <artifactId>org.openhab.io.multimedia.tts.marytts</artifactId>
             <version>${oh1.version}</version>
-        </dependency>    	
+        </dependency>
+        <dependency>
+            <groupId>org.openhab.io</groupId>
+            <artifactId>org.openhab.io.transport.mqtt</artifactId>
+            <version>${oh1.version}</version>
+        </dependency>
     </dependencies>
 
     <repositories>

--- a/distribution/src/assemble/resources/addons/conf/services/mqtt.cfg
+++ b/distribution/src/assemble/resources/addons/conf/services/mqtt.cfg
@@ -1,0 +1,29 @@
+# URL to the MQTT broker, e.g. tcp://localhost:1883 or ssl://localhost:8883
+#<broker>.url=tcp://localhost:1883
+
+# Optional. Client id (max 23 chars) to use when connecting to the broker.
+# If not provided a default one is generated.
+#<broker>.clientId=<clientid>
+
+# Optional. User id to authenticate with the broker.
+#<broker>.user=<username>
+
+# Optional. Password to authenticate with the broker.
+#<broker>.pwd=<password>
+
+# Optional. Set the quality of service level for sending messages to this broker. 
+# Possible values are 0 (Deliver at most once),1 (Deliver at least once) or 2 
+# (Deliver exactly once). Defaults to 0.
+#<broker>.qos=<qos>
+
+# Optional. True or false. Defines if the broker should retain the messages sent to
+# it. Defaults to false.
+#<broker>.retain=<retain>
+
+# Optional. True or false. Defines if messages are published asynchronously or
+# synchronously. Defaults to true.
+#<broker>.async=<async>
+
+# Optional. Defines the last will and testament that is sent when this client goes offline
+# Format: topic:message:qos:retained <br/>
+#<broker>.lwt=<last will definition>

--- a/docs/sources/addons.md
+++ b/docs/sources/addons.md
@@ -59,6 +59,7 @@ All optional add-ons for openHAB 2 are [available in a separate download](https:
 | LCN | Binding |
 | Milight | Binding |
 | Modbus | Binding |
+| MQTT | Binding |
 | Networkhealth | Binding |
 | Nibeheatpump | Binding |
 | NTP | Binding |


### PR DESCRIPTION
Adds the 1.x MQTT binding to list of compatible v1.x bindings.

Tested using the same broker and item configurations from my version 1 setup and appears to work fine.

Signed-off-by: Dan Nixon <dan@dan-nixon.com> (GitHub: DanNixon)