### PR TITLE
Document Ecobee and Nest bindings compatibility

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -237,6 +237,11 @@
         </dependency>
         <dependency>
             <groupId>org.openhab.binding</groupId>
+            <artifactId>org.openhab.binding.ecobee</artifactId>
+            <version>${oh1.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.openhab.binding</groupId>
             <artifactId>org.openhab.binding.energenie</artifactId>
             <version>${oh1.version}</version>
         </dependency>
@@ -318,6 +323,11 @@
         <dependency>
             <groupId>org.openhab.binding</groupId>
             <artifactId>org.openhab.binding.mqtt</artifactId>
+            <version>${oh1.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.openhab.binding</groupId>
+            <artifactId>org.openhab.binding.nest</artifactId>
             <version>${oh1.version}</version>
         </dependency>
         <dependency>
@@ -437,6 +447,11 @@
             <version>${oh1.version}</version>
         </dependency>    	
 
+        <dependency>
+            <groupId>org.openhab.action</groupId>
+            <artifactId>org.openhab.action.ecobee</artifactId>
+            <version>${oh1.version}</version>
+        </dependency>
         <dependency>
             <groupId>org.openhab.action</groupId>
             <artifactId>org.openhab.action.mail</artifactId>

--- a/distribution/src/assemble/resources/addons/conf/services/ecobee.cfg
+++ b/distribution/src/assemble/resources/addons/conf/services/ecobee.cfg
@@ -1,0 +1,24 @@
+################################ Ecobee Binding #######################################
+#
+# the private API key issued be Ecobee to use the API (required, replace with your own)
+#appkey=9T4huoUXlT5b5qNpEJvM5sqTMgaNCFoV
+
+# the application scope used when authorizing the binding
+# choices are smartWrite,smartRead, or ems, or multiple (required, comma-separated, no spaces)
+#scope=smartWrite
+
+# Rate at which to check if poll is to run, in ms (optional, defaults to 5000)
+#granularity=5000
+
+# Data refresh interval in ms (optional, defaults to 180000)
+#refresh=180000
+
+# Time in ms to wait after successful update, command or action before refresh (optional, defaults to 6000)
+#quickpoll=6000
+
+# Time in ms to allow an API request to complete (optional, defaults to 20000)
+#timeout=20000
+
+# the temperature scale to use when sending or receiving temperatures
+# optional, defaults to Fahrenheit (F)
+#tempscale=C

--- a/distribution/src/assemble/resources/addons/conf/services/nest.cfg
+++ b/distribution/src/assemble/resources/addons/conf/services/nest.cfg
@@ -1,0 +1,17 @@
+############################## Nest binding ###########################################
+#
+# Data refresh interval in ms (optional, defaults to 60000)
+#refresh=
+
+# HTTP request timeout in ms (optional, defaults to 10000)
+#timeout=
+
+# the Nest Client ID needed to use the API, must be supplied
+#client_id=
+
+# the Nest Client Secret needed to use the API, must be supplied
+#client_secret=
+
+# the PIN code that Nest presented when you authorized the above client, must be supplied
+#pin_code=
+

--- a/docs/sources/addons.md
+++ b/docs/sources/addons.md
@@ -42,6 +42,7 @@ All optional add-ons for openHAB 2 are [available in a separate download](https:
 | Comfo Air | Binding |
 | Denon | Binding |
 | DMX (OLA) | Binding |
+| Ecobee | Binding |
 | EDS OWServer | Binding |
 | Energenie | Binding |
 | Enocean | Binding |
@@ -60,6 +61,7 @@ All optional add-ons for openHAB 2 are [available in a separate download](https:
 | Milight | Binding |
 | Modbus | Binding |
 | MQTT | Binding |
+| Nest | Binding |
 | Networkhealth | Binding |
 | Nibeheatpump | Binding |
 | NTP | Binding |
@@ -86,6 +88,7 @@ All optional add-ons for openHAB 2 are [available in a separate download](https:
 | MongoDB | Persistence |
 | Logging | Persistence |
 | JPA | Persistence |
+| Ecobee | Action |
 | Mail | Action |
 | Pushover | Action |
 | Telegram | Action |


### PR DESCRIPTION
Adds the 1.x Ecobee action/binding and Nest binding to list of compatible v1.x bindings.

Tested using the same config from OH 1.8 and appears to work fine.

Signed-off-by: John Cocula <john@cocula.com>