### PR TITLE
removed sonos feature as it is already defined in the distro

### DIFF
--- a/features/openhab-addons/src/main/feature/feature.xml
+++ b/features/openhab-addons/src/main/feature/feature.xml
@@ -93,10 +93,6 @@
         <bundle start-level="80">mvn:org.openhab.binding/org.openhab.binding.smaenergymeter/${project.version}</bundle>
     </feature>
 
-    <feature name="openhab-binding-sonos" description="Sonos Binding" version="${project.version}">
-        <feature>esh-binding-sonos</feature>
-    </feature>
-
     <feature name="openhab-binding-squeezebox" description="Squeezebox Binding" version="${project.version}">
         <feature>openhab-runtime-base</feature>
         <feature>openhab-transport-upnp</feature>


### PR DESCRIPTION
Signed-off-by: Kai Kreuzer <kai@openhab.org>